### PR TITLE
-t flag uses default branch by default. Added stable option and adjus…

### DIFF
--- a/build_tools/gtkwave/install_gtkwave.sh
+++ b/build_tools/gtkwave/install_gtkwave.sh
@@ -20,50 +20,50 @@ CLEANUP=false
 USAGE="$(basename "$0") [-h] [-i] [-c] [-d dir] [-t tag] -- Clone latested tagged ${PROJ} version and build it. Optionally select the build directory and version, install binaries and cleanup setup files.
 
 where:
-    -h  		show this help text
-    -i  		install binaries
-    -c			cleanup project
-    -d dir 		build files in \"dir\" (default: ${BUILDFOLDER})
-    -t tag		specify version (git tag or commit hash) to pull (default: Latest tag)"
+    -h          show this help text
+    -i          install binaries
+    -c          cleanup project
+    -d dir      build files in \"dir\" (default: ${BUILDFOLDER})
+    -t tag      specify version (git tag or commit hash) to pull (default: Latest tag)"
    
  
 while getopts ":i" OPTION; do
-	case $OPTION in
-		i)	INSTALL=true
-		   	echo "-i set: Installing built binaries"
-		   	;;
-	esac
+    case $OPTION in
+        i)  INSTALL=true
+            echo "-i set: Installing built binaries"
+            ;;
+    esac
 done
 
 OPTIND=1
 
 while getopts ':hicd:t:' OPTION; do
-	case "$OPTION" in
-    	h) 	echo "$USAGE"
-       		exit
-       		;;
-		c) 	if [ $INSTALL = false ]; then
-				>&2 echo -e "${RED}ERROR: -c only makes sense if the built binaries were installed before (-i)"
-				exit 1
-			fi
-			CLEANUP=true
-		   	echo "-c set: Removing build directory"
-		   	;;
-		d)	echo "-d set: Using folder $OPTARG"
-			BUILDFOLDER="$OPTARG"
-			;;
-		t)	echo "-t set: Using version $OPTARG"
-			TAG="$OPTARG"
-			;;
-		:) 	echo -e "${RED}ERROR: missing argument for -${OPTARG}\n${NC}" >&2
-		   	echo "$USAGE" >&2
-		   	exit 1
-		   	;;
-	   \?) 	echo -e "${RED}ERROR: illegal option: -${OPTARG}\n${NC}" >&2
-		   	echo "$USAGE" >&2
-		   	exit 1
-		   	;;
-	esac
+    case "$OPTION" in
+        h)  echo "$USAGE"
+            exit
+            ;;
+        c)  if [ $INSTALL = false ]; then
+                >&2 echo -e "${RED}ERROR: -c only makes sense if the built binaries were installed before (-i)"
+                exit 1
+            fi
+            CLEANUP=true
+            echo "-c set: Removing build directory"
+            ;;
+        d)  echo "-d set: Using folder $OPTARG"
+            BUILDFOLDER="$OPTARG"
+            ;;
+        t)  echo "-t set: Using version $OPTARG"
+            TAG="$OPTARG"
+            ;;
+        :)  echo -e "${RED}ERROR: missing argument for -${OPTARG}\n${NC}" >&2
+            echo "$USAGE" >&2
+            exit 1
+            ;;
+       \?)  echo -e "${RED}ERROR: illegal option: -${OPTARG}\n${NC}" >&2
+            echo "$USAGE" >&2
+            exit 1
+            ;;
+    esac
 done
 shift $((OPTIND - 1))
 
@@ -82,7 +82,7 @@ trap 'echo -e "${RED}ERROR: Script was terminated unexpectedly, cleaning up file
 
 # fetch specified version 
 if [ ! -d $BUILDFOLDER ]; then
-	mkdir $BUILDFOLDER
+    mkdir $BUILDFOLDER
 fi
 
 pushd $BUILDFOLDER > /dev/null
@@ -93,25 +93,24 @@ fi
 
 pushd $PROJ > /dev/null
 
-if [ "$TAG" = "latest" ]; then
-	TAGLIST=`git rev-list --tags --max-count=1`
-	
-	# tags found?
-	if [ -n "$TAGLIST" ]; then
-	    COMMIT_HASH="`git describe --tags $TAGLIST`"
-		git checkout "$COMMIT_HASH"
-	else
-	    COMMIT_HASH="$(git rev-parse HEAD)"
-		>&2 echo -e "${RED}WARNING: No git tags found, using master branch${NC}"
-	fi
+if [ "$TAG" == "stable" ]; then
+    TAGLIST=`git rev-list --tags --max-count=1`
+    
+    # tags found?
+    if [ -n "$TAGLIST" ]; then
+        COMMIT_HASH="`git describe --tags $TAGLIST`"
+        git checkout "$COMMIT_HASH"
+    else
+        COMMIT_HASH="$(git rev-parse HEAD)"
+        >&2 echo -e "${RED}WARNING: No git tags found, using default branch${NC}"
+    fi
 else
-	git checkout $TAG
-	
-	if [ "$TAG" == "master" ] || [ "${TAG::7}" = "develop" ]; then
-	    COMMIT_HASH="$(git rev-parse HEAD)"
-	else
-	    COMMIT_HASH="$TAG"
-	fi
+    if [ "$TAG" == "default" ] || [ "$TAG" == "latest" ]; then
+        COMMIT_HASH="$(git rev-parse HEAD)"
+    else
+        git checkout $TAG
+        COMMIT_HASH="$TAG"
+    fi
 fi
 
 
@@ -120,7 +119,7 @@ fi
 make -j$(nproc)
 
 if [ $INSTALL = true ]; then
-	make install
+    make install
 fi
 
 # return to first folder and store version
@@ -129,5 +128,5 @@ echo "GTKWave: $COMMIT_HASH" >> "$VERSIONFILE"
 
 # cleanup if wanted
 if [ $CLEANUP = true ]; then
-	rm -rf $BUILDFOLDER
+    rm -rf $BUILDFOLDER
 fi

--- a/build_tools/icestorm/install_icestorm.sh
+++ b/build_tools/icestorm/install_icestorm.sh
@@ -23,50 +23,50 @@ CLEANUP=false
 USAGE="$(basename "$0") [-h] [-i] [-c] [-d dir] [-t tag] -- Clone latested tagged ${PROJ} version and build it. Optionally select the build directory and version, install binaries and cleanup setup files.
 
 where:
-    -h  		show this help text
-    -i  		install binaries
-    -c			cleanup project
-    -d dir 		build files in \"dir\" (default: ${BUILDFOLDER})
-    -t tag		specify version (git tag or commit hash) to pull (default: Latest tag)"
+    -h          show this help text
+    -i          install binaries
+    -c          cleanup project
+    -d dir      build files in \"dir\" (default: ${BUILDFOLDER})
+    -t tag      specify version (git tag or commit hash) to pull (default: Latest tag)"
    
  
 while getopts ":i" OPTION; do
-	case $OPTION in
-		i)	INSTALL=true
-		   	echo "-i set: Installing built binaries"
-		   	;;
-	esac
+    case $OPTION in
+        i)  INSTALL=true
+            echo "-i set: Installing built binaries"
+            ;;
+    esac
 done
 
 OPTIND=1
 
 while getopts ':hicd:t:' OPTION; do
-	case "$OPTION" in
-    	h) 	echo "$USAGE"
-       		exit
-       		;;
-		c) 	if [ $INSTALL = false ]; then
-				>&2 echo -e "${RED}ERROR: -c only makes sense if the built binaries were installed before (-i)"
-				exit 1
-			fi
-			CLEANUP=true
-		   	echo "-c set: Removing build directory"
-		   	;;
-		d)	echo "-d set: Using folder $OPTARG"
-			BUILDFOLDER="$OPTARG"
-			;;
-		t)	echo "-t set: Using version $OPTARG"
-			TAG="$OPTARG"
-			;;
-		:) 	echo -e "${RED}ERROR: missing argument for -${OPTARG}\n${NC}" >&2
-		   	echo "$USAGE" >&2
-		   	exit 1
-		   	;;
-	   \?) 	echo -e "${RED}ERROR: illegal option: -${OPTARG}\n${NC}" >&2
-		   	echo "$USAGE" >&2
-		   	exit 1
-		   	;;
-	esac
+    case "$OPTION" in
+        h)  echo "$USAGE"
+            exit
+            ;;
+        c)  if [ $INSTALL = false ]; then
+                >&2 echo -e "${RED}ERROR: -c only makes sense if the built binaries were installed before (-i)"
+                exit 1
+            fi
+            CLEANUP=true
+            echo "-c set: Removing build directory"
+            ;;
+        d)  echo "-d set: Using folder $OPTARG"
+            BUILDFOLDER="$OPTARG"
+            ;;
+        t)  echo "-t set: Using version $OPTARG"
+            TAG="$OPTARG"
+            ;;
+        :)  echo -e "${RED}ERROR: missing argument for -${OPTARG}\n${NC}" >&2
+            echo "$USAGE" >&2
+            exit 1
+            ;;
+        \?) echo -e "${RED}ERROR: illegal option: -${OPTARG}\n${NC}" >&2
+            echo "$USAGE" >&2
+            exit 1
+            ;;
+    esac
 done
 shift $((OPTIND - 1))
 
@@ -85,7 +85,7 @@ trap 'echo -e "${RED}ERROR: Script was terminated unexpectedly, cleaning up file
 
 # fetch specified version 
 if [ ! -d $BUILDFOLDER ]; then
-	mkdir $BUILDFOLDER
+    mkdir $BUILDFOLDER
 fi
 
 pushd $BUILDFOLDER > /dev/null
@@ -96,32 +96,31 @@ fi
 
 pushd $PROJ > /dev/null
 
-if [ "$TAG" = "latest" ]; then
-	TAGLIST=`git rev-list --tags --max-count=1`
-	
-	# tags found?
-	if [ -n "$TAGLIST" ]; then
-	    COMMIT_HASH="`git describe --tags $TAGLIST`"
-		git checkout "$COMMIT_HASH"
-	else
-	    COMMIT_HASH="$(git rev-parse HEAD)"
-		>&2 echo -e "${RED}WARNING: No git tags found, using master branch${NC}"
-	fi
+if [ "$TAG" == "stable" ]; then
+    TAGLIST=`git rev-list --tags --max-count=1`
+    
+    # tags found?
+    if [ -n "$TAGLIST" ]; then
+        COMMIT_HASH="`git describe --tags $TAGLIST`"
+        git checkout "$COMMIT_HASH"
+    else
+        COMMIT_HASH="$(git rev-parse HEAD)"
+        >&2 echo -e "${RED}WARNING: No git tags found, using default branch${NC}"
+    fi
 else
-	git checkout $TAG
-	
-	if [ "$TAG" == "master" ] || [ "${TAG::7}" = "develop" ]; then
-	    COMMIT_HASH="$(git rev-parse HEAD)"
-	else
-	    COMMIT_HASH="$TAG"
-	fi
+    if [ "$TAG" == "default" ] || [ "$TAG" == "latest" ]; then
+        COMMIT_HASH="$(git rev-parse HEAD)"
+    else
+        git checkout $TAG
+        COMMIT_HASH="$TAG"
+    fi
 fi
 
 # build and install if wanted
 make -j$(nproc)
 
 if [ $INSTALL = true ]; then
-	make install
+    make install
 fi
 
 # allow any user to access ice fpgas (no sudo)
@@ -139,6 +138,6 @@ echo "Icestorm: $COMMIT_HASH" >> "$VERSIONFILE"
 
 # cleanup if wanted
 if [ $CLEANUP = true ]; then
-	rm -rf $BUILDFOLDER
+    rm -rf $BUILDFOLDER
 fi
 

--- a/build_tools/install_everything.sh
+++ b/build_tools/install_everything.sh
@@ -35,34 +35,34 @@ where:
     -d dir      build files in \"dir\" (default: ${BUILDFOLDER})"
 
 while getopts ':chopvd:' OPTION; do
-	case "$OPTION" in
-	    c)  echo "-c set: Cleaning up everything in the end"
-	        CLEANUP=true
-	        ;;
-		d)	echo "-d set: Using folder $OPTARG"
-		    BUILDFOLDER="$OPTARG"
-		    ;;
-    	h) 	echo "$USAGE"
-       		exit
-       		;;
+    case "$OPTION" in
+        c)  echo "-c set: Cleaning up everything in the end"
+            CLEANUP=true
+            ;;
+        d)  echo "-d set: Using folder $OPTARG"
+            BUILDFOLDER="$OPTARG"
+            ;;
+        h)  echo "$USAGE"
+            exit
+            ;;
         o)  echo "-o set: Adding users \"${OPTARG}\" to dialout"
             DIALOUT_USERS="$OPTARG"
             ;;
         p)  echo "-o set: Copying version file to desktop of \"${OPTARG}\""
             VERSION_FILE_USERS="$OPTARG"
             ;;
-       	v)  echo "-v set: Being verbose"
-       	    VERBOSE=true
-       	    ;;
-		:) 	echo -e "${RED}ERROR: missing argument for -${OPTARG}\n${NC}" >&2
-		   	echo "$USAGE" >&2
-		   	exit 1
-		   	;;
-	   \?) 	echo -e "${RED}ERROR: illegal option: -${OPTARG}\n${NC}" >&2
-		   	echo "$USAGE" >&2
-		   	exit 1
-		   	;;
-	esac
+        v)  echo "-v set: Being verbose"
+            VERBOSE=true
+            ;;
+        :)  echo -e "${RED}ERROR: missing argument for -${OPTARG}\n${NC}" >&2
+            echo "$USAGE" >&2
+            exit 1
+            ;;
+       \?)  echo -e "${RED}ERROR: illegal option: -${OPTARG}\n${NC}" >&2
+            echo "$USAGE" >&2
+            exit 1
+            ;;
+    esac
 done
 shift $((OPTIND - 1))
 
@@ -360,7 +360,7 @@ source config.cfg
 # create and cd into buildfolder
 if [ ! -d $BUILDFOLDER ]; then
     echo_verbose "Creating build folder \"${BUILDFOLDER}\""
-	mkdir $BUILDFOLDER
+    mkdir $BUILDFOLDER
 fi
 
 cp -r install_build_essentials.sh $BUILDFOLDER

--- a/build_tools/nextpnr/install_nextpnr.sh
+++ b/build_tools/nextpnr/install_nextpnr.sh
@@ -31,71 +31,71 @@ ICESTORM_ICEBOX_DIR="icestorm"
 USAGE="$(basename "$0") [-h] [-i] [-c] [-e] [-d dir] [-l path] [-t tag] -- Clone latested tagged ${PROJ} version and build it. Optionally select the build directory, chip files, chipset and version, install binaries and cleanup setup files.
 
 where:
-    -h  		show this help text
-    -i  		install binaries
-    -c			cleanup project
-    -e			install NextPNR for ecp5 chips (default: ice40)
-    -d dir 		build files in \"dir\" (default: ${BUILDFOLDER})
-    -l path		use local chip files for ice40 or ecp5 from \"path\" (use empty string for default path in ubuntu)
-    -t tag		specify version (git tag or commit hash) to pull (default: Latest tag)"
+    -h          show this help text
+    -i          install binaries
+    -c          cleanup project
+    -e          install NextPNR for ecp5 chips (default: ice40)
+    -d dir      build files in \"dir\" (default: ${BUILDFOLDER})
+    -l path     use local chip files for ice40 or ecp5 from \"path\" (use empty string for default path in ubuntu)
+    -t tag      specify version (git tag or commit hash) to pull (default: Latest tag)"
    
  
 while getopts ":ie" OPTION; do
-	case $OPTION in
-		i)	INSTALL=true
-		   	echo "-i set: Installing built binaries"
-		   	;;
-		e)	echo "-e set: Installing NextPNR for ecp5 chipset"
-			CHIP="ecp5"
-			;;
-	esac
+    case $OPTION in
+        i)  INSTALL=true
+            echo "-i set: Installing built binaries"
+            ;;
+        e)  echo "-e set: Installing NextPNR for ecp5 chipset"
+            CHIP="ecp5"
+            ;;
+    esac
 done
 
 OPTIND=1
 
 while getopts ':hiecd:t:l:' OPTION; do
-	case "$OPTION" in
-    	h) 	echo "$USAGE"
-       		exit
-       		;;
-		c) 	if [ $INSTALL = false ]; then
-				>&2 echo -e "${RED}ERROR: -c only makes sense if the built binaries were installed before (-i)"
-				exit 1
-			fi
-			CLEANUP=true
-		   	echo "-c set: Removing build directory"
-		   	;;
-		d)	echo "-d set: Using folder $OPTARG"
-			BUILDFOLDER="$OPTARG"
-			;;
-		t)	echo "-t set: Using version $OPTARG"
-			TAG="$OPTARG"
-			;;
-		l)	echo "-l set: Using local chip data"			
-			if [ -z "$OPTARG" ]; then
-				if [ "$CHIP" = "ice40" ]; then
-					LIBPATH="$ICESTORM_LIB"
-				else
-					LIBPATH="$TRELLIS_LIB"
-				fi
-			else
-				if [ ! -d "$OPTARG" ]; then
-					echo -e "${RED}ERROR: Invalid path \"${OPTARG}\""
-					exit 1
-				fi
-				
-				LIBPATH="$OPTARG"
-			fi
-			;;
-		:) 	echo -e "${RED}ERROR: missing argument for -${OPTARG}\n${NC}" >&2
-		   	echo "$USAGE" >&2
-		   	exit 1
-		   	;;
-	   \?) 	echo -e "${RED}ERROR: illegal option: -${OPTARG}\n${NC}" "$OPTARG" >&2
-		   	echo "$USAGE" >&2
-		   	exit 1
-		   	;;
-	esac
+    case "$OPTION" in
+    h)  echo "$USAGE"
+        exit
+        ;;
+    c)  if [ $INSTALL = false ]; then
+            >&2 echo -e "${RED}ERROR: -c only makes sense if the built binaries were installed before (-i)"
+            exit 1
+        fi
+        CLEANUP=true
+        echo "-c set: Removing build directory"
+        ;;
+    d)  echo "-d set: Using folder $OPTARG"
+        BUILDFOLDER="$OPTARG"
+        ;;
+    t)  echo "-t set: Using version $OPTARG"
+        TAG="$OPTARG"
+        ;;
+    l)  echo "-l set: Using local chip data"
+        if [ -z "$OPTARG" ]; then
+            if [ "$CHIP" = "ice40" ]; then
+                LIBPATH="$ICESTORM_LIB"
+            else
+                LIBPATH="$TRELLIS_LIB"
+            fi
+        else
+            if [ ! -d "$OPTARG" ]; then
+                echo -e "${RED}ERROR: Invalid path \"${OPTARG}\""
+                exit 1
+            fi
+
+            LIBPATH="$OPTARG"
+        fi
+        ;;
+    :)  echo -e "${RED}ERROR: missing argument for -${OPTARG}\n${NC}" >&2
+        echo "$USAGE" >&2
+        exit 1
+        ;;
+    \?) echo -e "${RED}ERROR: illegal option: -${OPTARG}\n${NC}" "$OPTARG" >&2
+        echo "$USAGE" >&2
+        exit 1
+        ;;
+    esac
 done
 shift $((OPTIND - 1))
 
@@ -114,7 +114,7 @@ trap 'echo -e "${RED}ERROR: Script was terminated unexpectedly, cleaning up file
 
 # fetch specified version 
 if [ ! -d $BUILDFOLDER ]; then
-	mkdir $BUILDFOLDER
+    mkdir $BUILDFOLDER
 fi
 
 pushd $BUILDFOLDER > /dev/null
@@ -125,80 +125,79 @@ fi
 
 pushd $PROJ > /dev/null
 
-if [ "$TAG" = "latest" ]; then
-	TAGLIST=`git rev-list --tags --max-count=1`
-	
-	# tags found?
-	if [ -n "$TAGLIST" ]; then
-	    COMMIT_HASH="`git describe --tags $TAGLIST`"
-		git checkout "$COMMIT_HASH"
-	else
-	    COMMIT_HASH="$(git rev-parse HEAD)"
-		>&2 echo -e "${RED}WARNING: No git tags found, using master branch${NC}"
-	fi
+if [ "$TAG" == "stable" ]; then
+    TAGLIST=`git rev-list --tags --max-count=1`
+    
+    # tags found?
+    if [ -n "$TAGLIST" ]; then
+        COMMIT_HASH="`git describe --tags $TAGLIST`"
+        git checkout "$COMMIT_HASH"
+    else
+        COMMIT_HASH="$(git rev-parse HEAD)"
+        >&2 echo -e "${RED}WARNING: No git tags found, using default branch${NC}"
+    fi
 else
-	git checkout $TAG
-	
-	if [ "$TAG" == "master" ] || [ "${TAG::7}" = "develop" ]; then
-	    COMMIT_HASH="$(git rev-parse HEAD)"
-	else
-	    COMMIT_HASH="$TAG"
-	fi
+    if [ "$TAG" == "default" ] || [ "$TAG" == "latest" ]; then
+        COMMIT_HASH="$(git rev-parse HEAD)"
+    else
+        git checkout $TAG
+        COMMIT_HASH="$TAG"
+    fi
 fi
 
 # build and install if wanted
 # chip ice40?
 if [ "$CHIP" = "ice40" ]; then
-	# is icestorm installed?
-	if [ -n "$LIBPATH" ]; then
-		cmake -DARCH=ice40 -DICEBOX_ROOT=${LIBPATH} .
-	else
-		echo "Note: Pulling Icestorm from Github."
-		
-		if [ ! -d "$ICESTORM_PROJ" ]; then
-			git clone $ICESTORM_REPO "$ICESTORM_ICEBOX_DIR"
-		fi
-		
-		NEXTPNR_FOLDER=`pwd -P`
-		# build icebox (chipdbs)
-		pushd "${ICESTORM_ICEBOX_DIR}/icebox" > /dev/null
-		make -j$(nproc)
-		make install DESTDIR=$NEXTPNR_FOLDER PREFIX=''
-		popd +0 > /dev/null
-		# build icetime (timing)
-		pushd "${ICESTORM_ICEBOX_DIR}/icetime" > /dev/null
-		make -j$(nproc) PREFIX=$NEXTPNR_FOLDER
-		make install DESTDIR=$NEXTPNR_FOLDER PREFIX=''
-		popd +0 > /dev/null
-		# build nextpnr-ice40 next
-		cmake -j$(nproc) -DARCH=ice40 -DICEBOX_ROOT="${NEXTPNR_FOLDER}/share/icebox" .
-	fi
+    # is icestorm installed?
+    if [ -n "$LIBPATH" ]; then
+        cmake -DARCH=ice40 -DICEBOX_ROOT=${LIBPATH} .
+    else
+        echo "Note: Pulling Icestorm from Github."
+        
+        if [ ! -d "$ICESTORM_PROJ" ]; then
+            git clone $ICESTORM_REPO "$ICESTORM_ICEBOX_DIR"
+        fi
+        
+        NEXTPNR_FOLDER=`pwd -P`
+        # build icebox (chipdbs)
+        pushd "${ICESTORM_ICEBOX_DIR}/icebox" > /dev/null
+        make -j$(nproc)
+        make install DESTDIR=$NEXTPNR_FOLDER PREFIX=''
+        popd +0 > /dev/null
+        # build icetime (timing)
+        pushd "${ICESTORM_ICEBOX_DIR}/icetime" > /dev/null
+        make -j$(nproc) PREFIX=$NEXTPNR_FOLDER
+        make install DESTDIR=$NEXTPNR_FOLDER PREFIX=''
+        popd +0 > /dev/null
+        # build nextpnr-ice40 next
+        cmake -j$(nproc) -DARCH=ice40 -DICEBOX_ROOT="${NEXTPNR_FOLDER}/share/icebox" .
+    fi
 # chip ecp5?
 else
-	# is project trellis installed?
-	if [ -d "$LIBPATH" ]; then
-		cmake -j$(nproc) -DARCH=ecp5 -DTRELLIS_INSTALL_PREFIX=${LIBPATH} .
-	else
-		echo "Note: Pulling Trellis from Github."
-		
-		if [ ! -d "$TRELLIS_PROJ" ]; then
-			git clone --recursive $TRELLIS_REPO
-		fi
-		
-		TRELLIS_MAKE_PATH="$(pwd -P)/${TRELLIS_PROJ}/libtrellis"
-		pushd "$TRELLIS_MAKE_PATH" > /dev/null
-		cmake -j$(nproc) -DCMAKE_INSTALL_PREFIX="$TRELLIS_MAKE_PATH" .
-		make -j$(nproc)
-		make install
-		popd +0 > /dev/null
-		cmake -j$(nproc) -DARCH=ecp5 -DTRELLIS_INSTALL_PREFIX="$TRELLIS_MAKE_PATH" .
-	fi
+    # is project trellis installed?
+    if [ -d "$LIBPATH" ]; then
+        cmake -j$(nproc) -DARCH=ecp5 -DTRELLIS_INSTALL_PREFIX=${LIBPATH} .
+    else
+        echo "Note: Pulling Trellis from Github."
+        
+        if [ ! -d "$TRELLIS_PROJ" ]; then
+            git clone --recursive $TRELLIS_REPO
+        fi
+        
+        TRELLIS_MAKE_PATH="$(pwd -P)/${TRELLIS_PROJ}/libtrellis"
+        pushd "$TRELLIS_MAKE_PATH" > /dev/null
+        cmake -j$(nproc) -DCMAKE_INSTALL_PREFIX="$TRELLIS_MAKE_PATH" .
+        make -j$(nproc)
+        make install
+        popd +0 > /dev/null
+        cmake -j$(nproc) -DARCH=ecp5 -DTRELLIS_INSTALL_PREFIX="$TRELLIS_MAKE_PATH" .
+    fi
 fi
 
 make -j$(nproc)
 
 if [ $INSTALL = true ]; then
-	make install
+    make install
 fi
 
 # return to first folder and store version
@@ -212,5 +211,5 @@ fi
 
 # cleanup if wanted
 if [ $CLEANUP = true ]; then
-	rm -rf $BUILDFOLDER
+    rm -rf $BUILDFOLDER
 fi

--- a/build_tools/openocd_vexriscv/install_openocd_vexriscv.sh
+++ b/build_tools/openocd_vexriscv/install_openocd_vexriscv.sh
@@ -24,50 +24,50 @@ CONFIGURE_STRING="--prefix=/usr/local --program-suffix=-vexriscv
 USAGE="$(basename "$0") [-h] [-i] [-c] [-d dir] [-t tag] -- Clone latested tagged ${PROJ} version and build it. Optionally select the build directory and version, install binaries and cleanup setup files.
 
 where:
-    -h  		show this help text
-    -i  		install binaries
-    -c			cleanup project
-    -d dir 		build files in \"dir\" (default: ${BUILDFOLDER})
-    -t tag		specify version (git tag or commit hash) to pull (default: Latest tag)"
+    -h          show this help text
+    -i          install binaries
+    -c          cleanup project
+    -d dir      build files in \"dir\" (default: ${BUILDFOLDER})
+    -t tag      specify version (git tag or commit hash) to pull (default: Latest tag)"
    
  
 while getopts ":i" OPTION; do
-	case $OPTION in
-		i)	INSTALL=true
-		   	echo "-i set: Installing built binaries"
-		   	;;
-	esac
+    case $OPTION in
+        i)  INSTALL=true
+            echo "-i set: Installing built binaries"
+            ;;
+    esac
 done
 
 OPTIND=1
 
 while getopts ':hicd:t:' OPTION; do
-	case "$OPTION" in
-    	h) 	echo "$USAGE"
-       		exit
-       		;;
-		c) 	if [ $INSTALL = false ]; then
-				>&2 echo -e "${RED}ERROR: -c only makes sense if the built binaries were installed before (-i)"
-				exit 1
-			fi
-			CLEANUP=true
-		   	echo "-c set: Removing build directory"
-		   	;;
-		d)	echo "-d set: Using folder $OPTARG"
-			BUILDFOLDER="$OPTARG"
-			;;
-		t)	echo "-t set: Using version $OPTARG"
-			TAG="$OPTARG"
-			;;
-		:) 	echo -e "${RED}ERROR: missing argument for -${OPTARG}\n${NC}" >&2
-		   	echo "$USAGE" >&2
-		   	exit 1
-		   	;;
-	   \?) 	echo -e "${RED}ERROR: illegal option: -${OPTARG}\n${NC}" >&2
-		   	echo "$USAGE" >&2
-		   	exit 1
-		   	;;
-	esac
+    case "$OPTION" in
+        h)  echo "$USAGE"
+            exit
+            ;;
+        c)  if [ $INSTALL = false ]; then
+                >&2 echo -e "${RED}ERROR: -c only makes sense if the built binaries were installed before (-i)"
+                exit 1
+            fi
+            CLEANUP=true
+            echo "-c set: Removing build directory"
+            ;;
+        d)  echo "-d set: Using folder $OPTARG"
+            BUILDFOLDER="$OPTARG"
+            ;;
+        t)  echo "-t set: Using version $OPTARG"
+            TAG="$OPTARG"
+            ;;
+        :)  echo -e "${RED}ERROR: missing argument for -${OPTARG}\n${NC}" >&2
+            echo "$USAGE" >&2
+            exit 1
+            ;;
+       \?)  echo -e "${RED}ERROR: illegal option: -${OPTARG}\n${NC}" >&2
+            echo "$USAGE" >&2
+            exit 1
+            ;;
+    esac
 done
 shift $((OPTIND - 1))
 
@@ -86,7 +86,7 @@ trap 'echo -e "${RED}ERROR: Script was terminated unexpectedly, cleaning up file
 
 # fetch specified version 
 if [ ! -d $BUILDFOLDER ]; then
-	mkdir $BUILDFOLDER
+    mkdir $BUILDFOLDER
 fi
 
 pushd $BUILDFOLDER > /dev/null
@@ -97,11 +97,24 @@ fi
 
 pushd $PROJ > /dev/null
 
-if [ "$TAG" != "latest" ]; then
-	git checkout $TAG
-	COMMIT_HASH="$TAG"
+if [ "$TAG" == "stable" ]; then
+    TAGLIST=`git rev-list --tags --max-count=1`
+    
+    # tags found?
+    if [ -n "$TAGLIST" ]; then
+        COMMIT_HASH="`git describe --tags $TAGLIST`"
+        git checkout "$COMMIT_HASH"
+    else
+        COMMIT_HASH="$(git rev-parse HEAD)"
+        >&2 echo -e "${RED}WARNING: No git tags found, using default branch${NC}"
+    fi
 else
-    COMMIT_HASH="$(git rev-parse HEAD)"
+    if [ "$TAG" == "default" ] || [ "$TAG" == "latest" ]; then
+        COMMIT_HASH="$(git rev-parse HEAD)"
+    else
+        git checkout $TAG
+        COMMIT_HASH="$TAG"
+    fi
 fi
 
 # build and install if wanted
@@ -111,7 +124,7 @@ fi
 make -j$(nproc)
 
 if [ $INSTALL = true ]; then
-	make install
+    make install
 fi
 
 # return to first folder and store version
@@ -120,6 +133,6 @@ echo "OpenOCD-Vexriscv: $COMMIT_HASH" >> "$VERSIONFILE"
 
 # cleanup if wanted
 if [ $CLEANUP = true ]; then
-	rm -rf $BUILDFOLDER
+    rm -rf $BUILDFOLDER
 fi
 

--- a/build_tools/riscv_tools/install_riscv.sh
+++ b/build_tools/riscv_tools/install_riscv.sh
@@ -39,50 +39,50 @@ RISCV_NEWLIB=default
 # Taken from Sifive:
 # https://github.com/sifive/freedom-tools/blob/120fa4d48815fc9e87c59374c499849934f2ce10/Makefile
 NEWLIB_MULTILIBS_GEN="\
-	rv32e-ilp32e--c \
-	rv32ea-ilp32e--m \
-	rv32em-ilp32e--c \
-	rv32eac-ilp32e-- \
-	rv32emac-ilp32e-- \
-	rv32i-ilp32--c,f,fc,fd,fdc \
-	rv32ia-ilp32-rv32ima,rv32iaf,rv32imaf,rv32iafd,rv32imafd- \
-	rv32im-ilp32--c,f,fc,fd,fdc \
-	rv32iac-ilp32--f,fd \
-	rv32imac-ilp32-rv32imafc,rv32imafdc- \
-	rv32if-ilp32f--c,d,dc \
-	rv32iaf-ilp32f--c,d,dc \
-	rv32imf-ilp32f--d \
-	rv32imaf-ilp32f-rv32imafd- \
-	rv32imfc-ilp32f--d \
-	rv32imafc-ilp32f-rv32imafdc- \
-	rv32ifd-ilp32d--c \
-	rv32imfd-ilp32d--c \
-	rv32iafd-ilp32d-rv32imafd,rv32iafdc- \
-	rv32imafdc-ilp32d-- \
-	rv64i-lp64--c,f,fc,fd,fdc \
-	rv64ia-lp64-rv64ima,rv64iaf,rv64imaf,rv64iafd,rv64imafd- \
-	rv64im-lp64--c,f,fc,fd,fdc \
-	rv64iac-lp64--f,fd \
-	rv64imac-lp64-rv64imafc,rv64imafdc- \
-	rv64if-lp64f--c,d,dc \
-	rv64iaf-lp64f--c,d,dc \
-	rv64imf-lp64f--d \
-	rv64imaf-lp64f-rv64imafd- \
-	rv64imfc-lp64f--d \
-	rv64imafc-lp64f-rv64imafdc- \
-	rv64ifd-lp64d--c \
-	rv64imfd-lp64d--c \
-	rv64iafd-lp64d-rv64imafd,rv64iafdc- \
-	rv64imafdc-lp64d--"
+    rv32e-ilp32e--c \
+    rv32ea-ilp32e--m \
+    rv32em-ilp32e--c \
+    rv32eac-ilp32e-- \
+    rv32emac-ilp32e-- \
+    rv32i-ilp32--c,f,fc,fd,fdc \
+    rv32ia-ilp32-rv32ima,rv32iaf,rv32imaf,rv32iafd,rv32imafd- \
+    rv32im-ilp32--c,f,fc,fd,fdc \
+    rv32iac-ilp32--f,fd \
+    rv32imac-ilp32-rv32imafc,rv32imafdc- \
+    rv32if-ilp32f--c,d,dc \
+    rv32iaf-ilp32f--c,d,dc \
+    rv32imf-ilp32f--d \
+    rv32imaf-ilp32f-rv32imafd- \
+    rv32imfc-ilp32f--d \
+    rv32imafc-ilp32f-rv32imafdc- \
+    rv32ifd-ilp32d--c \
+    rv32imfd-ilp32d--c \
+    rv32iafd-ilp32d-rv32imafd,rv32iafdc- \
+    rv32imafdc-ilp32d-- \
+    rv64i-lp64--c,f,fc,fd,fdc \
+    rv64ia-lp64-rv64ima,rv64iaf,rv64imaf,rv64iafd,rv64imafd- \
+    rv64im-lp64--c,f,fc,fd,fdc \
+    rv64iac-lp64--f,fd \
+    rv64imac-lp64-rv64imafc,rv64imafdc- \
+    rv64if-lp64f--c,d,dc \
+    rv64iaf-lp64f--c,d,dc \
+    rv64imf-lp64f--d \
+    rv64imaf-lp64f-rv64imafd- \
+    rv64imfc-lp64f--d \
+    rv64imafc-lp64f-rv64imafdc- \
+    rv64ifd-lp64d--c \
+    rv64imfd-lp64d--c \
+    rv64iafd-lp64d-rv64imafd,rv64iafdc- \
+    rv64imafdc-lp64d--"
 
 
 # Linux install (cross-compile for linux)
 # Default value from riscv-gcc repository
 GLIBC_MULTILIBS_GEN="\
-	rv32imac-ilp32-rv32ima,rv32imaf,rv32imafd,rv32imafc,rv32imafdc- \
-	rv32imafdc-ilp32d-rv32imafd- \
-	rv64imac-lp64-rv64ima,rv64imaf,rv64imafd,rv64imafc,rv64imafdc- \
-	rv64imafdc-lp64d-rv64imafd-"'
+    rv32imac-ilp32-rv32ima,rv32imaf,rv32imafd,rv32imafc,rv32imafdc- \
+    rv32imafdc-ilp32d-rv32imafd- \
+    rv64imac-lp64-rv64ima,rv64imaf,rv64imafd,rv64imafc,rv64imafdc- \
+    rv64imafdc-lp64d-rv64imafd-"'
 
 
 # parse arguments
@@ -99,50 +99,50 @@ where:
     -p path     choose install path (default: /opt/riscv)"
 
 while getopts ':hcend:t:u:p:' OPTION; do
-	case "$OPTION" in
-    	h) 	echo "$USAGE"
-       		exit
-       		;;
-		c) 	if [ $INSTALL = false ]; then
-				>&2 echo -e "${RED}ERROR: -c only makes sense if the built binaries were installed before (-i)"
-				exit 1
-			fi
-			CLEANUP=true
-		   	echo "-c set: Removing build directory"
-		   	;;
-		e)  EXPORTPATH=true
-		    echo "-e set: Extending PATH by RiscV binary path"
-		    ;;
-    	n) 	echo "-n set: Using newlib cross-compiler"
-       		NEWLIB=true
-       		TOOLCHAIN_SUFFIX="newlib-multilib"
-       		;;
-		d)	echo "-d set: Using folder $OPTARG"
-			BUILDFOLDER="$OPTARG"
-			;;
-		t)	echo "-t set: Using version $OPTARG"
-			TAG="$OPTARG"
-			;;
-		p)	echo "-p set: Using install path $OPTARG"
-			INSTALL_PATH="$OPTARG"
-			;;
-		u)  echo "-u set: Installing for user $OPTARG"
-		    PROFILE_PATH="$(grep $OPTARG /etc/passwd | cut -d ":" -f6)/.profile"
-		    
-		    if [ ! -f "$PROFILE_PATH" ]; then
-		        echo -e "${RED}ERROR: No .profile file found for user \"${OPTARG}\"${NC}" >&2
-		        exit 1;
-		    fi
-		    ;;
-		:) 	echo -e "${RED}ERROR: missing argument for -${OPTARG}\n${NC}" >&2
-		   	echo "$USAGE" >&2
-		   	exit 1
-		   	;;
-	   \?) 	echo -e "${RED}ERROR: illegal option: -${OPTARG}\n${NC}" >&2
-		   	echo "$USAGE" >&2
-		   	exit 1
-		   	;;
-	esac
+    case "$OPTION" in
+        h)  echo "$USAGE"
+            exit
+            ;;
+        c)  if [ $INSTALL = false ]; then
+                >&2 echo -e "${RED}ERROR: -c only makes sense if the built binaries were installed before (-i)"
+                exit 1
+            fi
+            CLEANUP=true
+            echo "-c set: Removing build directory"
+            ;;
+        e)  EXPORTPATH=true
+            echo "-e set: Extending PATH by RiscV binary path"
+            ;;
+        n)  echo "-n set: Using newlib cross-compiler"
+            NEWLIB=true
+            TOOLCHAIN_SUFFIX="newlib-multilib"
+            ;;
+        d)  echo "-d set: Using folder $OPTARG"
+            BUILDFOLDER="$OPTARG"
+            ;;
+        t)  echo "-t set: Using version $OPTARG"
+            TAG="$OPTARG"
+            ;;
+        p)  echo "-p set: Using install path $OPTARG"
+            INSTALL_PATH="$OPTARG"
+            ;;
+        u)  echo "-u set: Installing for user $OPTARG"
+            PROFILE_PATH="$(grep $OPTARG /etc/passwd | cut -d ":" -f6)/.profile"
+            
+            if [ ! -f "$PROFILE_PATH" ]; then
+                echo -e "${RED}ERROR: No .profile file found for user \"${OPTARG}\"${NC}" >&2
+                exit 1;
+            fi
+            ;;
+        :)  echo -e "${RED}ERROR: missing argument for -${OPTARG}\n${NC}" >&2
+            echo "$USAGE" >&2
+            exit 1
+            ;;
+       \?)  echo -e "${RED}ERROR: illegal option: -${OPTARG}\n${NC}" >&2
+            echo "$USAGE" >&2
+            exit 1
+            ;;
+    esac
 done
 shift $((OPTIND - 1))
 
@@ -171,7 +171,7 @@ CFG_LOCATION=`pwd -P`
 
 # fetch specified version 
 if [ ! -d $BUILDFOLDER ]; then
-	mkdir $BUILDFOLDER
+    mkdir $BUILDFOLDER
 fi
 
 pushd $BUILDFOLDER > /dev/null
@@ -260,6 +260,6 @@ echo "$VERSIONLIST" >> "$VERSIONFILE"
 
 # cleanup if wanted
 if [ $CLEANUP = true ]; then
-	rm -rf $BUILDFOLDER
+    rm -rf $BUILDFOLDER
 fi
 

--- a/build_tools/riscv_tools/versions.cfg
+++ b/build_tools/riscv_tools/versions.cfg
@@ -17,46 +17,46 @@ RISCV_NEWLIB=default
 # Taken from Sifive:
 # https://github.com/sifive/freedom-tools/blob/120fa4d48815fc9e87c59374c499849934f2ce10/Makefile
 NEWLIB_MULTILIBS_GEN="\
-	rv32e-ilp32e--c \
-	rv32ea-ilp32e--m \
-	rv32em-ilp32e--c \
-	rv32eac-ilp32e-- \
-	rv32emac-ilp32e-- \
-	rv32i-ilp32--c,f,fc,fd,fdc \
-	rv32ia-ilp32-rv32ima,rv32iaf,rv32imaf,rv32iafd,rv32imafd- \
-	rv32im-ilp32--c,f,fc,fd,fdc \
-	rv32iac-ilp32--f,fd \
-	rv32imac-ilp32-rv32imafc,rv32imafdc- \
-	rv32if-ilp32f--c,d,dc \
-	rv32iaf-ilp32f--c,d,dc \
-	rv32imf-ilp32f--d \
-	rv32imaf-ilp32f-rv32imafd- \
-	rv32imfc-ilp32f--d \
-	rv32imafc-ilp32f-rv32imafdc- \
-	rv32ifd-ilp32d--c \
-	rv32imfd-ilp32d--c \
-	rv32iafd-ilp32d-rv32imafd,rv32iafdc- \
-	rv32imafdc-ilp32d-- \
-	rv64i-lp64--c,f,fc,fd,fdc \
-	rv64ia-lp64-rv64ima,rv64iaf,rv64imaf,rv64iafd,rv64imafd- \
-	rv64im-lp64--c,f,fc,fd,fdc \
-	rv64iac-lp64--f,fd \
-	rv64imac-lp64-rv64imafc,rv64imafdc- \
-	rv64if-lp64f--c,d,dc \
-	rv64iaf-lp64f--c,d,dc \
-	rv64imf-lp64f--d \
-	rv64imaf-lp64f-rv64imafd- \
-	rv64imfc-lp64f--d \
-	rv64imafc-lp64f-rv64imafdc- \
-	rv64ifd-lp64d--c \
-	rv64imfd-lp64d--c \
-	rv64iafd-lp64d-rv64imafd,rv64iafdc- \
-	rv64imafdc-lp64d--"
+    rv32e-ilp32e--c \
+    rv32ea-ilp32e--m \
+    rv32em-ilp32e--c \
+    rv32eac-ilp32e-- \
+    rv32emac-ilp32e-- \
+    rv32i-ilp32--c,f,fc,fd,fdc \
+    rv32ia-ilp32-rv32ima,rv32iaf,rv32imaf,rv32iafd,rv32imafd- \
+    rv32im-ilp32--c,f,fc,fd,fdc \
+    rv32iac-ilp32--f,fd \
+    rv32imac-ilp32-rv32imafc,rv32imafdc- \
+    rv32if-ilp32f--c,d,dc \
+    rv32iaf-ilp32f--c,d,dc \
+    rv32imf-ilp32f--d \
+    rv32imaf-ilp32f-rv32imafd- \
+    rv32imfc-ilp32f--d \
+    rv32imafc-ilp32f-rv32imafdc- \
+    rv32ifd-ilp32d--c \
+    rv32imfd-ilp32d--c \
+    rv32iafd-ilp32d-rv32imafd,rv32iafdc- \
+    rv32imafdc-ilp32d-- \
+    rv64i-lp64--c,f,fc,fd,fdc \
+    rv64ia-lp64-rv64ima,rv64iaf,rv64imaf,rv64iafd,rv64imafd- \
+    rv64im-lp64--c,f,fc,fd,fdc \
+    rv64iac-lp64--f,fd \
+    rv64imac-lp64-rv64imafc,rv64imafdc- \
+    rv64if-lp64f--c,d,dc \
+    rv64iaf-lp64f--c,d,dc \
+    rv64imf-lp64f--d \
+    rv64imaf-lp64f-rv64imafd- \
+    rv64imfc-lp64f--d \
+    rv64imafc-lp64f-rv64imafdc- \
+    rv64ifd-lp64d--c \
+    rv64imfd-lp64d--c \
+    rv64iafd-lp64d-rv64imafd,rv64iafdc- \
+    rv64imafdc-lp64d--"
 
 # Linux install (cross-compile for linux)
 # Default value from riscv-gcc repository
 GLIBC_MULTILIBS_GEN="\
-	rv32imac-ilp32-rv32ima,rv32imaf,rv32imafd,rv32imafc,rv32imafdc- \
-	rv32imafdc-ilp32d-rv32imafd- \
-	rv64imac-lp64-rv64ima,rv64imaf,rv64imafd,rv64imafc,rv64imafdc- \
-	rv64imafdc-lp64d-rv64imafd-"
+    rv32imac-ilp32-rv32ima,rv32imaf,rv32imafd,rv32imafc,rv32imafdc- \
+    rv32imafdc-ilp32d-rv32imafd- \
+    rv64imac-lp64-rv64ima,rv64imaf,rv64imafd,rv64imafc,rv64imafdc- \
+    rv64imafdc-lp64d-rv64imafd-"

--- a/build_tools/trellis/install_trellis.sh
+++ b/build_tools/trellis/install_trellis.sh
@@ -20,50 +20,50 @@ CLEANUP=false
 USAGE="$(basename "$0") [-h] [-i] [-c] [-d dir] [-t tag] -- Clone latested tagged ${PROJ} version and build it. Optionally select the build directory and version, install binaries and cleanup setup files.
 
 where:
-    -h  		show this help text
-    -i  		install binaries
-    -c			cleanup project
-    -d dir 		build files in \"dir\" (default: ${BUILDFOLDER})
-    -t tag		specify version (git tag or commit hash) to pull (default: Latest tag)"
+    -h          show this help text
+    -i          install binaries
+    -c          cleanup project
+    -d dir      build files in \"dir\" (default: ${BUILDFOLDER})
+    -t tag      specify version (git tag or commit hash) to pull (default: Latest tag)"
    
  
 while getopts ":i" OPTION; do
-	case $OPTION in
-		i)	INSTALL=true
-		   	echo "-i set: Installing built binaries"
-		   	;;
-	esac
+    case $OPTION in
+        i)  INSTALL=true
+            echo "-i set: Installing built binaries"
+            ;;
+    esac
 done
 
 OPTIND=1
 
 while getopts ':hicd:t:' OPTION; do
-	case "$OPTION" in
-    	h) 	echo "$USAGE"
-       		exit
-       		;;
-		c) 	if [ $INSTALL = false ]; then
-				>&2 echo -e "${RED}ERROR: -c only makes sense if the built binaries were installed before (-i)"
-				exit 1
-			fi
-			CLEANUP=true
-		   	echo "-c set: Removing build directory"
-		   	;;
-		d)	echo "-d set: Using folder $OPTARG"
-			BUILDFOLDER="$OPTARG"
-			;;
-		t)	echo "-t set: Using version $OPTARG"
-			TAG="$OPTARG"
-			;;
-		:) 	echo -e "${RED}ERROR: missing argument for -${OPTARG}\n${NC}" >&2
-		   	echo "$USAGE" >&2
-		   	exit 1
-		   	;;
-	   \?) 	echo -e "${RED}ERROR: illegal option: -${OPTARG}\n${NC}" >&2
-		   	echo "$USAGE" >&2
-		   	exit 1
-		   	;;
-	esac
+    case "$OPTION" in
+        h)  echo "$USAGE"
+            exit
+            ;;
+        c)  if [ $INSTALL = false ]; then
+                >&2 echo -e "${RED}ERROR: -c only makes sense if the built binaries were installed before (-i)"
+                exit 1
+            fi
+            CLEANUP=true
+            echo "-c set: Removing build directory"
+            ;;
+        d)  echo "-d set: Using folder $OPTARG"
+            BUILDFOLDER="$OPTARG"
+            ;;
+        t)  echo "-t set: Using version $OPTARG"
+            TAG="$OPTARG"
+            ;;
+        :)  echo -e "${RED}ERROR: missing argument for -${OPTARG}\n${NC}" >&2
+            echo "$USAGE" >&2
+            exit 1
+            ;;
+       \?)  echo -e "${RED}ERROR: illegal option: -${OPTARG}\n${NC}" >&2
+            echo "$USAGE" >&2
+            exit 1
+            ;;
+    esac
 done
 shift $((OPTIND - 1))
 
@@ -82,7 +82,7 @@ trap 'echo -e "${RED}ERROR: Script was terminated unexpectedly, cleaning up file
 
 # fetch specified version 
 if [ ! -d $BUILDFOLDER ]; then
-	mkdir $BUILDFOLDER
+    mkdir $BUILDFOLDER
 fi
 
 pushd $BUILDFOLDER > /dev/null
@@ -93,14 +93,24 @@ fi
 
 pushd $PROJ > /dev/null
 
-# Cannot work with tags here, since:
-# a) Trellis released a bugged version with tag 1.0
-# b) Trellis does not care about Tags
-if [ "$TAG" != "latest" ]; then
-	git checkout $TAG
-	COMMIT_HASH="$TAG"
+if [ "$TAG" == "stable" ]; then
+    TAGLIST=`git rev-list --tags --max-count=1`
+    
+    # tags found?
+    if [ -n "$TAGLIST" ]; then
+        COMMIT_HASH="`git describe --tags $TAGLIST`"
+        git checkout "$COMMIT_HASH"
+    else
+        COMMIT_HASH="$(git rev-parse HEAD)"
+        >&2 echo -e "${RED}WARNING: No git tags found, using default branch${NC}"
+    fi
 else
-    COMMIT_HASH="$(git rev-parse HEAD)"
+    if [ "$TAG" == "default" ] || [ "$TAG" == "latest" ]; then
+        COMMIT_HASH="$(git rev-parse HEAD)"
+    else
+        git checkout $TAG
+        COMMIT_HASH="$TAG"
+    fi
 fi
 
 # build and install if wanted
@@ -108,7 +118,7 @@ cmake -DCMAKE_INSTALL_PREFIX=/usr .
 make -j$(nproc)
 
 if [ $INSTALL = true ]; then
-	make install
+    make install
 fi
 
 # return to first folder and store version
@@ -117,6 +127,6 @@ echo "Project-Trellis: $COMMIT_HASH" >> "$VERSIONFILE"
 
 # cleanup if wanted
 if [ $CLEANUP = true ]; then
-	rm -rf $BUILDFOLDER
+    rm -rf $BUILDFOLDER
 fi
 

--- a/build_tools/ujprog/install_ujprog.sh
+++ b/build_tools/ujprog/install_ujprog.sh
@@ -20,50 +20,50 @@ CLEANUP=false
 USAGE="$(basename "$0") [-h] [-i] [-c] [-d dir] [-t tag] -- Clone latested tagged ${PROJ} version and build it. Optionally select the build directory and version, install binaries and cleanup setup files.
 
 where:
-    -h  		show this help text
-    -i  		install binaries
-    -c			cleanup project
-    -d dir 		build files in \"dir\" (default: ${BUILDFOLDER})
-    -t tag		specify version (git tag or commit hash) to pull (default: Latest tag)"
+    -h          show this help text
+    -i          install binaries
+    -c          cleanup project
+    -d dir      build files in \"dir\" (default: ${BUILDFOLDER})
+    -t tag      specify version (git tag or commit hash) to pull (default: Latest tag)"
    
  
 while getopts ":i" OPTION; do
-	case $OPTION in
-		i)	INSTALL=true
-		   	echo "-i set: Installing built binaries"
-		   	;;
-	esac
+    case $OPTION in
+        i)  INSTALL=true
+            echo "-i set: Installing built binaries"
+            ;;
+    esac
 done
 
 OPTIND=1
 
 while getopts ':hicd:t:' OPTION; do
-	case "$OPTION" in
-    	h) 	echo "$USAGE"
-       		exit
-       		;;
-		c) 	if [ $INSTALL = false ]; then
-				>&2 echo -e "${RED}ERROR: -c only makes sense if the built binaries were installed before (-i)"
-				exit 1
-			fi
-			CLEANUP=true
-		   	echo "-c set: Removing build directory"
-		   	;;
-		d)	echo "-d set: Using folder $OPTARG"
-			BUILDFOLDER="$OPTARG"
-			;;
-		t)	echo "-t set: Using version $OPTARG"
-			TAG="$OPTARG"
-			;;
-		:) 	echo -e "${RED}ERROR: missing argument for -${OPTARG}\n${NC}" >&2
-		   	echo "$USAGE" >&2
-		   	exit 1
-		   	;;
-	   \?) 	echo -e "${RED}ERROR: illegal option: -${OPTARG}\n${NC}" >&2
-		   	echo "$USAGE" >&2
-		   	exit 1
-		   	;;
-	esac
+    case "$OPTION" in
+        h)  echo "$USAGE"
+            exit
+            ;;
+        c)  if [ $INSTALL = false ]; then
+                >&2 echo -e "${RED}ERROR: -c only makes sense if the built binaries were installed before (-i)"
+                exit 1
+            fi
+            CLEANUP=true
+            echo "-c set: Removing build directory"
+            ;;
+        d)  echo "-d set: Using folder $OPTARG"
+            BUILDFOLDER="$OPTARG"
+            ;;
+        t)  echo "-t set: Using version $OPTARG"
+            TAG="$OPTARG"
+            ;;
+        :)  echo -e "${RED}ERROR: missing argument for -${OPTARG}\n${NC}" >&2
+            echo "$USAGE" >&2
+            exit 1
+            ;;
+       \?)  echo -e "${RED}ERROR: illegal option: -${OPTARG}\n${NC}" >&2
+            echo "$USAGE" >&2
+            exit 1
+            ;;
+    esac
 done
 shift $((OPTIND - 1))
 
@@ -82,7 +82,7 @@ trap 'echo -e "${RED}ERROR: Script was terminated unexpectedly, cleaning up file
 
 # fetch specified version 
 if [ ! -d $BUILDFOLDER ]; then
-	mkdir $BUILDFOLDER
+    mkdir $BUILDFOLDER
 fi
 
 pushd $BUILDFOLDER > /dev/null
@@ -93,25 +93,24 @@ fi
 
 pushd $PROJ > /dev/null
 
-if [ "$TAG" = "latest" ]; then
-	TAGLIST=`git rev-list --tags --max-count=1`
-	
-	# tags found?
-	if [ -n "$TAGLIST" ]; then
-	    COMMIT_HASH="`git describe --tags $TAGLIST`"
-		git checkout "$COMMIT_HASH"
-	else
-	    COMMIT_HASH="$(git rev-parse HEAD)"
-		>&2 echo -e "${RED}WARNING: No git tags found, using master branch${NC}"
-	fi
+if [ "$TAG" == "stable" ]; then
+    TAGLIST=`git rev-list --tags --max-count=1`
+    
+    # tags found?
+    if [ -n "$TAGLIST" ]; then
+        COMMIT_HASH="`git describe --tags $TAGLIST`"
+        git checkout "$COMMIT_HASH"
+    else
+        COMMIT_HASH="$(git rev-parse HEAD)"
+        >&2 echo -e "${RED}WARNING: No git tags found, using default branch${NC}"
+    fi
 else
-	git checkout $TAG
-	
-	if [ "$TAG" == "master" ] || [ "${TAG::7}" = "develop" ]; then
-	    COMMIT_HASH="$(git rev-parse HEAD)"
-	else
-	    COMMIT_HASH="$TAG"
-	fi
+    if [ "$TAG" == "default" ] || [ "$TAG" == "latest" ]; then
+        COMMIT_HASH="$(git rev-parse HEAD)"
+    else
+        git checkout $TAG
+        COMMIT_HASH="$TAG"
+    fi
 fi
 
 # build and install if wanted
@@ -119,7 +118,7 @@ cp Makefile.linux Makefile
 make -j$(nproc)
 
 if [ $INSTALL = true ]; then
-	make install
+    make install
 fi
 
 # return to first folder and store version
@@ -128,6 +127,6 @@ echo "Ujprog: $COMMIT_HASH" >> "$VERSIONFILE"
 
 # cleanup if wanted
 if [ $CLEANUP = true ]; then
-	rm -rf $BUILDFOLDER
+    rm -rf $BUILDFOLDER
 fi
 

--- a/build_tools/verilator/install_verilator.sh
+++ b/build_tools/verilator/install_verilator.sh
@@ -20,50 +20,50 @@ CLEANUP=false
 USAGE="$(basename "$0") [-h] [-i] [-c] [-d dir] [-t tag] -- Clone latested tagged ${PROJ} version and build it. Optionally select the build directory and version, install binaries and cleanup setup files.
 
 where:
-    -h  		show this help text
-    -i  		install binaries
-    -c			cleanup project
-    -d dir 		build files in \"dir\" (default: ${BUILDFOLDER})
-    -t tag		specify version (git tag or commit hash) to pull (default: Latest tag)"
+    -h          show this help text
+    -i          install binaries
+    -c          cleanup project
+    -d dir      build files in \"dir\" (default: ${BUILDFOLDER})
+    -t tag      specify version (git tag or commit hash) to pull (default: Latest tag)"
    
  
 while getopts ":i" OPTION; do
-	case $OPTION in
-		i)	INSTALL=true
-		   	echo "-i set: Installing built binaries"
-		   	;;
-	esac
+    case $OPTION in
+        i)  INSTALL=true
+            echo "-i set: Installing built binaries"
+            ;;
+    esac
 done
 
 OPTIND=1
 
 while getopts ':hicd:t:' OPTION; do
-	case "$OPTION" in
-    	h) 	echo "$USAGE"
-       		exit
-       		;;
-		c) 	if [ $INSTALL = false ]; then
-				>&2 echo -e "${RED}ERROR: -c only makes sense if the built binaries were installed before (-i)"
-				exit 1
-			fi
-			CLEANUP=true
-		   	echo "-c set: Removing build directory"
-		   	;;
-		d)	echo "-d set: Using folder $OPTARG"
-			BUILDFOLDER="$OPTARG"
-			;;
-		t)	echo "-t set: Using version $OPTARG"
-			TAG="$OPTARG"
-			;;
-		:) 	echo -e "${RED}ERROR: missing argument for -${OPTARG}\n${NC}" >&2
-		   	echo "$USAGE" >&2
-		   	exit 1
-		   	;;
-	   \?) 	echo -e "${RED}ERROR: illegal option: -${OPTARG}\n${NC}" >&2
-		   	echo "$USAGE" >&2
-		   	exit 1
-		   	;;
-	esac
+    case "$OPTION" in
+        h)  echo "$USAGE"
+            exit
+            ;;
+        c)  if [ $INSTALL = false ]; then
+                >&2 echo -e "${RED}ERROR: -c only makes sense if the built binaries were installed before (-i)"
+                exit 1
+            fi
+            CLEANUP=true
+            echo "-c set: Removing build directory"
+            ;;
+        d)  echo "-d set: Using folder $OPTARG"
+            BUILDFOLDER="$OPTARG"
+            ;;
+        t)  echo "-t set: Using version $OPTARG"
+            TAG="$OPTARG"
+            ;;
+        :)  echo -e "${RED}ERROR: missing argument for -${OPTARG}\n${NC}" >&2
+            echo "$USAGE" >&2
+            exit 1
+            ;;
+       \?)  echo -e "${RED}ERROR: illegal option: -${OPTARG}\n${NC}" >&2
+            echo "$USAGE" >&2
+            exit 1
+            ;;
+    esac
 done
 shift $((OPTIND - 1))
 
@@ -82,7 +82,7 @@ trap 'echo -e "${RED}ERROR: Script was terminated unexpectedly, cleaning up file
 
 # fetch specified version 
 if [ ! -d $BUILDFOLDER ]; then
-	mkdir $BUILDFOLDER
+    mkdir $BUILDFOLDER
 fi
 
 pushd $BUILDFOLDER > /dev/null
@@ -93,33 +93,32 @@ fi
 
 pushd $PROJ > /dev/null
 
-if [ "$TAG" = "latest" ]; then
-	TAGLIST=`git rev-list --tags --max-count=1`
-	
-	# tags found?
-	if [ -n "$TAGLIST" ]; then
-	    COMMIT_HASH="`git describe --tags $TAGLIST`"
-		git checkout "$COMMIT_HASH"
-	else
-	    COMMIT_HASH="$(git rev-parse HEAD)"
-		>&2 echo -e "${RED}WARNING: No git tags found, using master branch${NC}"
-	fi
+if [ "$TAG" == "stable" ]; then
+    TAGLIST=`git rev-list --tags --max-count=1`
+    
+    # tags found?
+    if [ -n "$TAGLIST" ]; then
+        COMMIT_HASH="`git describe --tags $TAGLIST`"
+        git checkout "$COMMIT_HASH"
+    else
+        COMMIT_HASH="$(git rev-parse HEAD)"
+        >&2 echo -e "${RED}WARNING: No git tags found, using default branch${NC}"
+    fi
 else
-	git checkout $TAG
-	
-	if [ "$TAG" == "master" ] || [ "${TAG::7}" = "develop" ]; then
-	    COMMIT_HASH="$(git rev-parse HEAD)"
-	else
-	    COMMIT_HASH="$TAG"
-	fi
+    if [ "$TAG" == "default" ] || [ "$TAG" == "latest" ]; then
+        COMMIT_HASH="$(git rev-parse HEAD)"
+    else
+        git checkout $TAG
+        COMMIT_HASH="$TAG"
+    fi
 fi
 
 # build and install if wanted
 # unset var
 if [ -n "$BASH" ]; then
-	unset VERILATOR_ROOT
+    unset VERILATOR_ROOT
 else
-	unsetenv VERILATOR_ROOT
+    unsetenv VERILATOR_ROOT
 fi
 
 autoconf
@@ -127,7 +126,7 @@ autoconf
 make -j$(nproc)
 
 if [ $INSTALL = true ]; then
-	make install
+    make install
 fi
 
 # return to first folder and store version
@@ -136,6 +135,6 @@ echo "Verilator: $COMMIT_HASH" >> "$VERSIONFILE"
 
 # cleanup if wanted
 if [ $CLEANUP = true ]; then
-	rm -rf $BUILDFOLDER
+    rm -rf $BUILDFOLDER
 fi
 

--- a/build_tools/yosys/install_yosys.sh
+++ b/build_tools/yosys/install_yosys.sh
@@ -21,54 +21,54 @@ CLEANUP=false
 USAGE="$(basename "$0") [-h] [-i] [-c] [-d dir] [-b buildtool] [-t tag] -- Clone latested tagged ${PROJ} version and build it. Optionally select compiler (buildtool), build directory and version, install binaries and cleanup setup files.
 
 where:
-    -h  		show this help text
-    -i  		install binaries
-    -c			cleanup project
-    -d dir 		build files in \"dir\" (default: ${BUILDFOLDER})
-    -b compiler 	specify compiler (default: ${COMPILER}, alternative: gcc)
-    -t tag		specify version (git tag or commit hash) to pull (default: Latest tag)"
+    -h          show this help text
+    -i          install binaries
+    -c          cleanup project
+    -d dir      build files in \"dir\" (default: ${BUILDFOLDER})
+    -b compiler specify compiler (default: ${COMPILER}, alternative: gcc)
+    -t tag      specify version (git tag or commit hash) to pull (default: default branch)"
    
  
 while getopts ":i" OPTION; do
-	case $OPTION in
-		i)	INSTALL=true
-		   	echo "-i set: Installing built binaries"
-		   	;;
-	esac
+    case $OPTION in
+        i)  INSTALL=true
+            echo "-i set: Installing built binaries"
+            ;;
+    esac
 done
 
 OPTIND=1
 
 while getopts ':hicd:b:t:' OPTION; do
-	case "$OPTION" in
-    	h) 	echo "$USAGE"
-       		exit
-       		;;
-		c) 	if [ $INSTALL = false ]; then
-				>&2 echo -e "${RED}ERROR: -c only makes sense if the built binaries were installed before (-i)"
-				exit 1
-			fi
-			CLEANUP=true
-		   	echo "-c set: Removing build directory"
-		   	;;
-		d)	echo "-d set: Using folder $OPTARG"
-			BUILDFOLDER="$OPTARG"
-			;;
-		b)	echo "-b set: Using compiler $OPTARG"
-			COMPILER="$OPTARG"
-			;;
-		t)	echo "-t set: Using version $OPTARG"
-			TAG="$OPTARG"
-			;;
-		:) 	echo -e "${RED}ERROR: missing argument for -${OPTARG}\n" >&2
-		   	echo "$USAGE" >&2
-		   	exit 1
-		   	;;
-	   \?) 	echo -e "${RED}ERROR: illegal option: -${OPTARG}\n" >&2
-		   	echo "$USAGE" >&2
-		   	exit 1
-		   	;;
-	esac
+    case "$OPTION" in
+        h)  echo "$USAGE"
+            exit
+            ;;
+        c)  if [ $INSTALL = false ]; then
+                >&2 echo -e "${RED}ERROR: -c only makes sense if the built binaries were installed before (-i)"
+                exit 1
+            fi
+            CLEANUP=true
+            echo "-c set: Removing build directory"
+            ;;
+        d)  echo "-d set: Using folder $OPTARG"
+            BUILDFOLDER="$OPTARG"
+            ;;
+        b)  echo "-b set: Using compiler $OPTARG"
+            COMPILER="$OPTARG"
+            ;;
+        t)  echo "-t set: Using version $OPTARG"
+            TAG="$OPTARG"
+            ;;
+        :)  echo -e "${RED}ERROR: missing argument for -${OPTARG}\n${NC}" >&2
+            echo "$USAGE" >&2
+            exit 1
+            ;;
+        \?) echo -e "${RED}ERROR: illegal option: -${OPTARG}\n${NC}" >&2
+            echo "$USAGE" >&2
+            exit 1
+            ;;
+    esac
 done
 shift $((OPTIND - 1))
 
@@ -87,7 +87,7 @@ trap 'echo -e "${RED}ERROR: Script was terminated unexpectedly, cleaning up file
 
 # fetch specified version 
 if [ ! -d $BUILDFOLDER ]; then
-	mkdir $BUILDFOLDER
+    mkdir $BUILDFOLDER
 fi
 
 pushd $BUILDFOLDER > /dev/null
@@ -98,25 +98,24 @@ fi
 
 pushd $PROJ > /dev/null
 
-if [ "$TAG" = "latest" ]; then
-	TAGLIST=`git rev-list --tags --max-count=1`
-	
-	# tags found?
-	if [ -n "$TAGLIST" ]; then
-	    COMMIT_HASH="`git describe --tags $TAGLIST`"
-		git checkout "$COMMIT_HASH"
-	else
-	    COMMIT_HASH="$(git rev-parse HEAD)"
-		>&2 echo -e "${RED}WARNING: No git tags found, using master branch${NC}"
-	fi
+if [ "$TAG" == "stable" ]; then
+    TAGLIST=`git rev-list --tags --max-count=1`
+    
+    # tags found?
+    if [ -n "$TAGLIST" ]; then
+        COMMIT_HASH="`git describe --tags $TAGLIST`"
+        git checkout "$COMMIT_HASH"
+    else
+        COMMIT_HASH="$(git rev-parse HEAD)"
+        >&2 echo -e "${RED}WARNING: No git tags found, using default branch${NC}"
+    fi
 else
-	git checkout $TAG
-	
-	if [ "$TAG" == "master" ] || [ "${TAG::7}" = "develop" ]; then
-	    COMMIT_HASH="$(git rev-parse HEAD)"
-	else
-	    COMMIT_HASH="$TAG"
-	fi
+    if [ "$TAG" == "default" ] || [ "$TAG" == "latest" ]; then
+        COMMIT_HASH="$(git rev-parse HEAD)"
+    else
+        git checkout $TAG
+        COMMIT_HASH="$TAG"
+    fi
 fi
 
 # build and install if wanted
@@ -124,7 +123,7 @@ make config-$COMPILER
 make -j$(nproc)
 
 if [ $INSTALL = true ]; then
-	make install
+    make install
 fi
 
 # return to first folder and store version
@@ -133,6 +132,6 @@ echo "Yosys: $COMMIT_HASH" >> "$VERSIONFILE"
 
 # cleanup if wanted
 if [ $CLEANUP = true ]; then
-	rm -rf $BUILDFOLDER
+    rm -rf $BUILDFOLDER
 fi
 

--- a/documentation/source/direct_usage_of_the_scripts.rst
+++ b/documentation/source/direct_usage_of_the_scripts.rst
@@ -67,9 +67,14 @@ The *-c*, *-d*, *-i* and *-t* options are default options that available for eve
 
 The script creates a build folder, in which the source code for the project is being pulled into and in which temporary files might be stored. The name of the build folder can be specified by using the *-d* flag.
 
-The source code version that should be pulled can be specified by using the *-t* flag. You can specify a branch name, tag or commit hash. If this parameter is not specified, the default behavior is to scan the repository for the latest tag and pull the state associated with that tag. There are exceptions though. Some repositories abandoned the behavioral pattern of assigning tags to certain releases. If the default behavior would be to pull the latest tag, an obsolescent version of the source code would be used. Therefore, the scripts either have a hard-coded version check (if tag greater than x.y) or they just pull the master branch.
+The source code version that should be pulled can be specified by using the *-t* flag. You can specify a branch name, tag, commit hash or one of the following options:
 
-The tools only build the scripts by default. To also install them (using the default path specified in the tool itself), execute the script with the *-i* flag. There is currently no way to specify the installation path by using the scripts supplied with this project. A workaround would be to set environment variables used by the tools own build scripts.
+- default/latest: Pulls the default branch
+- stable: Pulls the latest tag
+
+The default behaviour (in case *-t* was not specified) is to pull the default branch. Before using the *stable* option, be sure to check whether the repository stopped to use tags at some point in time. If this is the case, the script will pull and use an outdated version, because it does not check timestamps. If no tags are found, the default branch is used.
+
+The scripts only build the tools by default. To also install them (using the default path specified in the tool itself), execute the script with the *-i* flag. There is currently no way to specify the installation path by using the scripts supplied with this project. A workaround would be to set environment variables used by the tools own build scripts.
 
 The last default flag is the *-c* flag, which deletes all files after the tool has been successfully installed. It is only relevant if the *-i* flag is supplied at the same invocation. Otherwise a tool that was build but not installed would be removed, which is obviously pointless because it is equivalent to no changes at all.
 


### PR DESCRIPTION
Problem: Issue #5 

Fix: Default behaviour of _-t_ flag is to use the default branch. This is also reflected by specifying "default" or "latest" with _-t_. By using "stable" as the value for _-t_, the latest tag is used if it exists.

Bonus: The new _-t_ behaviour is used in any script but riscv_tools now. Also replaced all tabs by spaces.