### PR TITLE
Only store tags in version file, in any other case use commit hash

### DIFF
--- a/build_tools/gtkwave/install_gtkwave.sh
+++ b/build_tools/gtkwave/install_gtkwave.sh
@@ -70,6 +70,46 @@ done
 
 shift "$((OPTIND - 1))"
 
+# This function does checkout the correct version and return the commit hash or tag name
+# Parameter 1: Branch name, commit hash, tag or one of the special keywords default/latest/stable
+# Parameter 2: Return variable name (commit hash or tag name)
+function select_and_get_project_version {
+    # Stable selected: Choose latest tag if available, otherwise use default branch
+    if [ "$1" == "stable" ]; then
+        local L_TAGLIST=`git rev-list --tags --max-count=1`
+        
+        # tags found?
+        if [ -n "$L_TAGLIST" ]; then
+            local L_COMMIT_HASH="`git describe --tags $L_TAGLIST`"
+            git checkout --recurse-submodules "$L_COMMIT_HASH"
+        else
+            git checkout --recurse-submodules $(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
+            local L_COMMIT_HASH="$(git rev-parse HEAD)"
+            >&2 echo -e "${RED}WARNING: No git tags found, using default branch${NC}"
+        fi
+    else
+        # Either checkout defaut/stable branch or use custom commit hash, tag or branch name
+        if [ "$1" == "default" ] || [ "$1" == "latest" ]; then
+            git checkout --recurse-submodules $(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
+            local L_COMMIT_HASH="$(git rev-parse HEAD)"
+        else
+            # Check if $1 contains a valid tag and use it as the version if it does
+            git checkout --recurse-submodules "$1"
+            local L_COMMIT_HASH="$(git rev-parse HEAD)"
+            
+            for CUR_TAG in `git tag --list`; do
+                if [ "$CUR_TAG" == "$1" ]; then
+                    L_COMMIT_HASH="$1"
+                    break
+                fi
+            done
+        fi
+    fi
+    
+    # Apply return value
+    eval "$2=\"$L_COMMIT_HASH\""
+}
+
 # exit when any command fails
 set -e
 
@@ -91,31 +131,11 @@ fi
 pushd $BUILDFOLDER > /dev/null
 
 if [ ! -d "$PROJ" ]; then
-    git clone $REPO
+    git clone --recursive $REPO
 fi
 
 pushd $PROJ > /dev/null
-
-if [ "$TAG" == "stable" ]; then
-    TAGLIST=`git rev-list --tags --max-count=1`
-    
-    # tags found?
-    if [ -n "$TAGLIST" ]; then
-        COMMIT_HASH="`git describe --tags $TAGLIST`"
-        git checkout "$COMMIT_HASH"
-    else
-        COMMIT_HASH="$(git rev-parse HEAD)"
-        >&2 echo -e "${RED}WARNING: No git tags found, using default branch${NC}"
-    fi
-else
-    if [ "$TAG" == "default" ] || [ "$TAG" == "latest" ]; then
-        COMMIT_HASH="$(git rev-parse HEAD)"
-    else
-        git checkout $TAG
-        COMMIT_HASH="$TAG"
-    fi
-fi
-
+select_and_get_project_version "$TAG" "COMMIT_HASH"
 
 # build and install if wanted
 if [ "$INSTALL_PREFIX" == "default" ]; then

--- a/build_tools/icestorm/install_icestorm.sh
+++ b/build_tools/icestorm/install_icestorm.sh
@@ -73,6 +73,46 @@ done
 
 shift "$((OPTIND - 1))"
 
+# This function does checkout the correct version and return the commit hash or tag name
+# Parameter 1: Branch name, commit hash, tag or one of the special keywords default/latest/stable
+# Parameter 2: Return variable name (commit hash or tag name)
+function select_and_get_project_version {
+    # Stable selected: Choose latest tag if available, otherwise use default branch
+    if [ "$1" == "stable" ]; then
+        local L_TAGLIST=`git rev-list --tags --max-count=1`
+        
+        # tags found?
+        if [ -n "$L_TAGLIST" ]; then
+            local L_COMMIT_HASH="`git describe --tags $L_TAGLIST`"
+            git checkout --recurse-submodules "$L_COMMIT_HASH"
+        else
+            git checkout --recurse-submodules $(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
+            local L_COMMIT_HASH="$(git rev-parse HEAD)"
+            >&2 echo -e "${RED}WARNING: No git tags found, using default branch${NC}"
+        fi
+    else
+        # Either checkout defaut/stable branch or use custom commit hash, tag or branch name
+        if [ "$1" == "default" ] || [ "$1" == "latest" ]; then
+            git checkout --recurse-submodules $(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
+            local L_COMMIT_HASH="$(git rev-parse HEAD)"
+        else
+            # Check if $1 contains a valid tag and use it as the version if it does
+            git checkout --recurse-submodules "$1"
+            local L_COMMIT_HASH="$(git rev-parse HEAD)"
+            
+            for CUR_TAG in `git tag --list`; do
+                if [ "$CUR_TAG" == "$1" ]; then
+                    L_COMMIT_HASH="$1"
+                    break
+                fi
+            done
+        fi
+    fi
+    
+    # Apply return value
+    eval "$2=\"$L_COMMIT_HASH\""
+}
+
 # exit when any command fails
 set -e
 
@@ -94,30 +134,12 @@ fi
 pushd $BUILDFOLDER > /dev/null
 
 if [ ! -d "$PROJ" ]; then
-    git clone $REPO
+    git clone --recursive $REPO
 fi
 
 pushd $PROJ > /dev/null
 
-if [ "$TAG" == "stable" ]; then
-    TAGLIST=`git rev-list --tags --max-count=1`
-    
-    # tags found?
-    if [ -n "$TAGLIST" ]; then
-        COMMIT_HASH="`git describe --tags $TAGLIST`"
-        git checkout "$COMMIT_HASH"
-    else
-        COMMIT_HASH="$(git rev-parse HEAD)"
-        >&2 echo -e "${RED}WARNING: No git tags found, using default branch${NC}"
-    fi
-else
-    if [ "$TAG" == "default" ] || [ "$TAG" == "latest" ]; then
-        COMMIT_HASH="$(git rev-parse HEAD)"
-    else
-        git checkout $TAG
-        COMMIT_HASH="$TAG"
-    fi
-fi
+select_and_get_project_version "$TAG" "COMMIT_HASH"
 
 # build and install if wanted
 make -j$(nproc)

--- a/build_tools/nextpnr/install_nextpnr.sh
+++ b/build_tools/nextpnr/install_nextpnr.sh
@@ -98,7 +98,48 @@ while getopts ':hecd:i:t:l:' OPTION; do
         ;;
     esac
 done
-shift $((OPTIND - 1))
+
+shift "$((OPTIND - 1))"
+
+# This function does checkout the correct version and return the commit hash or tag name
+# Parameter 1: Branch name, commit hash, tag or one of the special keywords default/latest/stable
+# Parameter 2: Return variable name (commit hash or tag name)
+function select_and_get_project_version {
+    # Stable selected: Choose latest tag if available, otherwise use default branch
+    if [ "$1" == "stable" ]; then
+        local L_TAGLIST=`git rev-list --tags --max-count=1`
+        
+        # tags found?
+        if [ -n "$L_TAGLIST" ]; then
+            local L_COMMIT_HASH="`git describe --tags $L_TAGLIST`"
+            git checkout --recurse-submodules "$L_COMMIT_HASH"
+        else
+            git checkout --recurse-submodules $(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
+            local L_COMMIT_HASH="$(git rev-parse HEAD)"
+            >&2 echo -e "${RED}WARNING: No git tags found, using default branch${NC}"
+        fi
+    else
+        # Either checkout defaut/stable branch or use custom commit hash, tag or branch name
+        if [ "$1" == "default" ] || [ "$1" == "latest" ]; then
+            git checkout --recurse-submodules $(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
+            local L_COMMIT_HASH="$(git rev-parse HEAD)"
+        else
+            # Check if $1 contains a valid tag and use it as the version if it does
+            git checkout --recurse-submodules "$1"
+            local L_COMMIT_HASH="$(git rev-parse HEAD)"
+            
+            for CUR_TAG in `git tag --list`; do
+                if [ "$CUR_TAG" == "$1" ]; then
+                    L_COMMIT_HASH="$1"
+                    break
+                fi
+            done
+        fi
+    fi
+    
+    # Apply return value
+    eval "$2=\"$L_COMMIT_HASH\""
+}
 
 # exit when any command fails
 set -e
@@ -121,30 +162,12 @@ fi
 pushd $BUILDFOLDER > /dev/null
 
 if [ ! -d "$PROJ" ]; then
-    git clone $REPO
+    git clone --recursive $REPO
 fi
 
 pushd $PROJ > /dev/null
 
-if [ "$TAG" == "stable" ]; then
-    TAGLIST=`git rev-list --tags --max-count=1`
-    
-    # tags found?
-    if [ -n "$TAGLIST" ]; then
-        COMMIT_HASH="`git describe --tags $TAGLIST`"
-        git checkout "$COMMIT_HASH"
-    else
-        COMMIT_HASH="$(git rev-parse HEAD)"
-        >&2 echo -e "${RED}WARNING: No git tags found, using default branch${NC}"
-    fi
-else
-    if [ "$TAG" == "default" ] || [ "$TAG" == "latest" ]; then
-        COMMIT_HASH="$(git rev-parse HEAD)"
-    else
-        git checkout $TAG
-        COMMIT_HASH="$TAG"
-    fi
-fi
+select_and_get_project_version "$TAG" "COMMIT_HASH"
 
 # build and install if wanted
 # chip ice40?

--- a/build_tools/openocd_vexriscv/install_openocd_vexriscv.sh
+++ b/build_tools/openocd_vexriscv/install_openocd_vexriscv.sh
@@ -76,6 +76,46 @@ done
 
 shift "$((OPTIND - 1))"
 
+# This function does checkout the correct version and return the commit hash or tag name
+# Parameter 1: Branch name, commit hash, tag or one of the special keywords default/latest/stable
+# Parameter 2: Return variable name (commit hash or tag name)
+function select_and_get_project_version {
+    # Stable selected: Choose latest tag if available, otherwise use default branch
+    if [ "$1" == "stable" ]; then
+        local L_TAGLIST=`git rev-list --tags --max-count=1`
+        
+        # tags found?
+        if [ -n "$L_TAGLIST" ]; then
+            local L_COMMIT_HASH="`git describe --tags $L_TAGLIST`"
+            git checkout --recurse-submodules "$L_COMMIT_HASH"
+        else
+            git checkout --recurse-submodules $(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
+            local L_COMMIT_HASH="$(git rev-parse HEAD)"
+            >&2 echo -e "${RED}WARNING: No git tags found, using default branch${NC}"
+        fi
+    else
+        # Either checkout defaut/stable branch or use custom commit hash, tag or branch name
+        if [ "$1" == "default" ] || [ "$1" == "latest" ]; then
+            git checkout --recurse-submodules $(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
+            local L_COMMIT_HASH="$(git rev-parse HEAD)"
+        else
+            # Check if $1 contains a valid tag and use it as the version if it does
+            git checkout --recurse-submodules "$1"
+            local L_COMMIT_HASH="$(git rev-parse HEAD)"
+            
+            for CUR_TAG in `git tag --list`; do
+                if [ "$CUR_TAG" == "$1" ]; then
+                    L_COMMIT_HASH="$1"
+                    break
+                fi
+            done
+        fi
+    fi
+    
+    # Apply return value
+    eval "$2=\"$L_COMMIT_HASH\""
+}
+
 # exit when any command fails
 set -e
 
@@ -101,27 +141,7 @@ if [ ! -d "$PROJ" ]; then
 fi
 
 pushd $PROJ > /dev/null
-
-if [ "$TAG" == "stable" ]; then
-    TAGLIST=`git rev-list --tags --max-count=1`
-    
-    # tags found?
-    if [ -n "$TAGLIST" ]; then
-        COMMIT_HASH="`git describe --tags $TAGLIST`"
-        git checkout --recurse-submodules "$COMMIT_HASH"
-    else
-        COMMIT_HASH="$(git rev-parse HEAD)"
-        >&2 echo -e "${RED}WARNING: No git tags found, using default branch${NC}"
-    fi
-else
-    if [ "$TAG" == "default" ] || [ "$TAG" == "latest" ]; then
-        COMMIT_HASH="$(git rev-parse HEAD)"
-    else
-        git checkout --recurse-submodules $TAG
-        COMMIT_HASH="$TAG"
-    fi
-fi
-
+select_and_get_project_version "$TAG" "COMMIT_HASH"
 # build and install if wanted
 ./bootstrap
 

--- a/build_tools/trellis/install_trellis.sh
+++ b/build_tools/trellis/install_trellis.sh
@@ -70,6 +70,46 @@ done
 
 shift "$((OPTIND - 1))"
 
+# This function does checkout the correct version and return the commit hash or tag name
+# Parameter 1: Branch name, commit hash, tag or one of the special keywords default/latest/stable
+# Parameter 2: Return variable name (commit hash or tag name)
+function select_and_get_project_version {
+    # Stable selected: Choose latest tag if available, otherwise use default branch
+    if [ "$1" == "stable" ]; then
+        local L_TAGLIST=`git rev-list --tags --max-count=1`
+        
+        # tags found?
+        if [ -n "$L_TAGLIST" ]; then
+            local L_COMMIT_HASH="`git describe --tags $L_TAGLIST`"
+            git checkout --recurse-submodules "$L_COMMIT_HASH"
+        else
+            git checkout --recurse-submodules $(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
+            local L_COMMIT_HASH="$(git rev-parse HEAD)"
+            >&2 echo -e "${RED}WARNING: No git tags found, using default branch${NC}"
+        fi
+    else
+        # Either checkout defaut/stable branch or use custom commit hash, tag or branch name
+        if [ "$1" == "default" ] || [ "$1" == "latest" ]; then
+            git checkout --recurse-submodules $(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
+            local L_COMMIT_HASH="$(git rev-parse HEAD)"
+        else
+            # Check if $1 contains a valid tag and use it as the version if it does
+            git checkout --recurse-submodules "$1"
+            local L_COMMIT_HASH="$(git rev-parse HEAD)"
+            
+            for CUR_TAG in `git tag --list`; do
+                if [ "$CUR_TAG" == "$1" ]; then
+                    L_COMMIT_HASH="$1"
+                    break
+                fi
+            done
+        fi
+    fi
+    
+    # Apply return value
+    eval "$2=\"$L_COMMIT_HASH\""
+}
+
 # exit when any command fails
 set -e
 
@@ -95,26 +135,7 @@ if [ ! -d "$PROJ" ]; then
 fi
 
 pushd $PROJ > /dev/null
-
-if [ "$TAG" == "stable" ]; then
-    TAGLIST=`git rev-list --tags --max-count=1`
-    
-    # tags found?
-    if [ -n "$TAGLIST" ]; then
-        COMMIT_HASH="`git describe --tags $TAGLIST`"
-        git checkout --recurse-submodules "$COMMIT_HASH"
-    else
-        COMMIT_HASH="$(git rev-parse HEAD)"
-        >&2 echo -e "${RED}WARNING: No git tags found, using default branch${NC}"
-    fi
-else
-    if [ "$TAG" == "default" ] || [ "$TAG" == "latest" ]; then
-        COMMIT_HASH="$(git rev-parse HEAD)"
-    else
-        git checkout --recurse-submodules $TAG
-        COMMIT_HASH="$TAG"
-    fi
-fi
+select_and_get_project_version "$TAG" "COMMIT_HASH"
 
 # build and install if wanted
 if [ "$INSTALL_PREFIX" == "default" ]; then

--- a/build_tools/ujprog/install_ujprog.sh
+++ b/build_tools/ujprog/install_ujprog.sh
@@ -70,6 +70,46 @@ done
 
 shift "$((OPTIND - 1))"
 
+# This function does checkout the correct version and return the commit hash or tag name
+# Parameter 1: Branch name, commit hash, tag or one of the special keywords default/latest/stable
+# Parameter 2: Return variable name (commit hash or tag name)
+function select_and_get_project_version {
+    # Stable selected: Choose latest tag if available, otherwise use default branch
+    if [ "$1" == "stable" ]; then
+        local L_TAGLIST=`git rev-list --tags --max-count=1`
+        
+        # tags found?
+        if [ -n "$L_TAGLIST" ]; then
+            local L_COMMIT_HASH="`git describe --tags $L_TAGLIST`"
+            git checkout --recurse-submodules "$L_COMMIT_HASH"
+        else
+            git checkout --recurse-submodules $(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
+            local L_COMMIT_HASH="$(git rev-parse HEAD)"
+            >&2 echo -e "${RED}WARNING: No git tags found, using default branch${NC}"
+        fi
+    else
+        # Either checkout defaut/stable branch or use custom commit hash, tag or branch name
+        if [ "$1" == "default" ] || [ "$1" == "latest" ]; then
+            git checkout --recurse-submodules $(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
+            local L_COMMIT_HASH="$(git rev-parse HEAD)"
+        else
+            # Check if $1 contains a valid tag and use it as the version if it does
+            git checkout --recurse-submodules "$1"
+            local L_COMMIT_HASH="$(git rev-parse HEAD)"
+            
+            for CUR_TAG in `git tag --list`; do
+                if [ "$CUR_TAG" == "$1" ]; then
+                    L_COMMIT_HASH="$1"
+                    break
+                fi
+            done
+        fi
+    fi
+    
+    # Apply return value
+    eval "$2=\"$L_COMMIT_HASH\""
+}
+
 # exit when any command fails
 set -e
 
@@ -95,26 +135,7 @@ if [ ! -d "$PROJ" ]; then
 fi
 
 pushd $PROJ > /dev/null
-
-if [ "$TAG" == "stable" ]; then
-    TAGLIST=`git rev-list --tags --max-count=1`
-    
-    # tags found?
-    if [ -n "$TAGLIST" ]; then
-        COMMIT_HASH="`git describe --tags $TAGLIST`"
-        git checkout --recurse-submodules "$COMMIT_HASH"
-    else
-        COMMIT_HASH="$(git rev-parse HEAD)"
-        >&2 echo -e "${RED}WARNING: No git tags found, using default branch${NC}"
-    fi
-else
-    if [ "$TAG" == "default" ] || [ "$TAG" == "latest" ]; then
-        COMMIT_HASH="$(git rev-parse HEAD)"
-    else
-        git checkout --recurse-submodules $TAG
-        COMMIT_HASH="$TAG"
-    fi
-fi
+select_and_get_project_version "$TAG" "COMMIT_HASH"
 
 # build and install if wanted
 cp Makefile.linux Makefile

--- a/build_tools/verilator/install_verilator.sh
+++ b/build_tools/verilator/install_verilator.sh
@@ -70,6 +70,46 @@ done
 
 shift "$((OPTIND - 1))"
 
+# This function does checkout the correct version and return the commit hash or tag name
+# Parameter 1: Branch name, commit hash, tag or one of the special keywords default/latest/stable
+# Parameter 2: Return variable name (commit hash or tag name)
+function select_and_get_project_version {
+    # Stable selected: Choose latest tag if available, otherwise use default branch
+    if [ "$1" == "stable" ]; then
+        local L_TAGLIST=`git rev-list --tags --max-count=1`
+        
+        # tags found?
+        if [ -n "$L_TAGLIST" ]; then
+            local L_COMMIT_HASH="`git describe --tags $L_TAGLIST`"
+            git checkout --recurse-submodules "$L_COMMIT_HASH"
+        else
+            git checkout --recurse-submodules $(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
+            local L_COMMIT_HASH="$(git rev-parse HEAD)"
+            >&2 echo -e "${RED}WARNING: No git tags found, using default branch${NC}"
+        fi
+    else
+        # Either checkout defaut/stable branch or use custom commit hash, tag or branch name
+        if [ "$1" == "default" ] || [ "$1" == "latest" ]; then
+            git checkout --recurse-submodules $(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
+            local L_COMMIT_HASH="$(git rev-parse HEAD)"
+        else
+            # Check if $1 contains a valid tag and use it as the version if it does
+            git checkout --recurse-submodules "$1"
+            local L_COMMIT_HASH="$(git rev-parse HEAD)"
+            
+            for CUR_TAG in `git tag --list`; do
+                if [ "$CUR_TAG" == "$1" ]; then
+                    L_COMMIT_HASH="$1"
+                    break
+                fi
+            done
+        fi
+    fi
+    
+    # Apply return value
+    eval "$2=\"$L_COMMIT_HASH\""
+}
+
 # exit when any command fails
 set -e
 
@@ -95,26 +135,7 @@ if [ ! -d "$PROJ" ]; then
 fi
 
 pushd $PROJ > /dev/null
-
-if [ "$TAG" == "stable" ]; then
-    TAGLIST=`git rev-list --tags --max-count=1`
-    
-    # tags found?
-    if [ -n "$TAGLIST" ]; then
-        COMMIT_HASH="`git describe --tags $TAGLIST`"
-        git checkout "$COMMIT_HASH"
-    else
-        COMMIT_HASH="$(git rev-parse HEAD)"
-        >&2 echo -e "${RED}WARNING: No git tags found, using default branch${NC}"
-    fi
-else
-    if [ "$TAG" == "default" ] || [ "$TAG" == "latest" ]; then
-        COMMIT_HASH="$(git rev-parse HEAD)"
-    else
-        git checkout $TAG
-        COMMIT_HASH="$TAG"
-    fi
-fi
+select_and_get_project_version "$TAG" "COMMIT_HASH"
 
 # build and install if wanted
 # unset var

--- a/build_tools/yosys/install_yosys.sh
+++ b/build_tools/yosys/install_yosys.sh
@@ -75,6 +75,46 @@ done
 
 shift "$((OPTIND - 1))"
 
+# This function does checkout the correct version and return the commit hash or tag name
+# Parameter 1: Branch name, commit hash, tag or one of the special keywords default/latest/stable
+# Parameter 2: Return variable name (commit hash or tag name)
+function select_and_get_project_version {
+    # Stable selected: Choose latest tag if available, otherwise use default branch
+    if [ "$1" == "stable" ]; then
+        local L_TAGLIST=`git rev-list --tags --max-count=1`
+        
+        # tags found?
+        if [ -n "$L_TAGLIST" ]; then
+            local L_COMMIT_HASH="`git describe --tags $L_TAGLIST`"
+            git checkout --recurse-submodules "$L_COMMIT_HASH"
+        else
+            git checkout --recurse-submodules $(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
+            local L_COMMIT_HASH="$(git rev-parse HEAD)"
+            >&2 echo -e "${RED}WARNING: No git tags found, using default branch${NC}"
+        fi
+    else
+        # Either checkout defaut/stable branch or use custom commit hash, tag or branch name
+        if [ "$1" == "default" ] || [ "$1" == "latest" ]; then
+            git checkout --recurse-submodules $(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
+            local L_COMMIT_HASH="$(git rev-parse HEAD)"
+        else
+            # Check if $1 contains a valid tag and use it as the version if it does
+            git checkout --recurse-submodules "$1"
+            local L_COMMIT_HASH="$(git rev-parse HEAD)"
+            
+            for CUR_TAG in `git tag --list`; do
+                if [ "$CUR_TAG" == "$1" ]; then
+                    L_COMMIT_HASH="$1"
+                    break
+                fi
+            done
+        fi
+    fi
+    
+    # Apply return value
+    eval "$2=\"$L_COMMIT_HASH\""
+}
+
 # exit when any command fails
 set -e
 
@@ -100,26 +140,7 @@ if [ ! -d "$PROJ" ]; then
 fi
 
 pushd $PROJ > /dev/null
-
-if [ "$TAG" == "stable" ]; then
-    TAGLIST=`git rev-list --tags --max-count=1`
-    
-    # tags found?
-    if [ -n "$TAGLIST" ]; then
-        COMMIT_HASH="`git describe --tags $TAGLIST`"
-        git checkout "$COMMIT_HASH"
-    else
-        COMMIT_HASH="$(git rev-parse HEAD)"
-        >&2 echo -e "${RED}WARNING: No git tags found, using default branch${NC}"
-    fi
-else
-    if [ "$TAG" == "default" ] || [ "$TAG" == "latest" ]; then
-        COMMIT_HASH="$(git rev-parse HEAD)"
-    else
-        git checkout $TAG
-        COMMIT_HASH="$TAG"
-    fi
-fi
+select_and_get_project_version "$TAG" "COMMIT_HASH"
 
 # build and install if wanted
 make config-$COMPILER

--- a/documentation/source/direct_usage_of_the_scripts.rst
+++ b/documentation/source/direct_usage_of_the_scripts.rst
@@ -64,7 +64,7 @@ This prints the following output (for verilator)::
 
 .. _tool-build-and-install-scripts-parameters:
 
-The *-c*, *-d*, *-i* and *-t* options are default options that available for every tool build and install script.
+The *-c*, *-d*, *-i* and *-t* options are default options that are available for every tool build and install script.
 
 The script creates a build folder, in which the source code for the project is being pulled into and in which temporary files might be stored. The name of the build folder can be specified by using the *-d* flag.
 


### PR DESCRIPTION
Problem: issue #16 

Solution: Check if custom project versions specified by *-t* are in the taglist. If they are, dump the tag in the version file. Otherwise dump the commit hash.

Bonus: On script error and restart the correct version is checked out in any case now (before it could happen that no checkout happened, even the current version and the specified version differed)