### PR TITLE
Commit hashes that point to a tag are now convereted to a tag name

### DIFF
--- a/build_tools/openocd/install_openocd.sh
+++ b/build_tools/openocd/install_openocd.sh
@@ -115,6 +115,8 @@ else
     select_and_get_project_version "$TAG" "COMMIT_HASH"
 fi
 
+echo "selected TAG: $COMMIT_HASH"
+
 # build and install if wanted
 ./bootstrap
 


### PR DESCRIPTION
Problem: Issue #42 
Fix: For any tool the version that is logged into the versionfile is now converted to a tag if possible. For riscv-tools, branch names are regarded as well (because they use branches instead of tags). In the latter case, the commit hash is stored in brackets after the branch name, in case it should get active for some reason (unlikely).