### PR TITLE
find_script() does now incorporate all *.cfg files

### DIFF
--- a/build_tools/libraries/library.sh
+++ b/build_tools/libraries/library.sh
@@ -297,11 +297,11 @@ function find_script {
         cp -r ../${L_NAME_LOWER} .
         eval "$2=\"$(pwd -P)/${L_NAME_LOWER}/install_${L_NAME_LOWER}_essentials.sh\""
         eval "$3=\"$(pwd -P)/${L_NAME_LOWER}/install_${L_NAME_LOWER}.sh\""
-        
-        # TODO: Extend to automatically find all configuration files
-        if [ -f "$(pwd -P)/${L_NAME_LOWER}/versions.cfg" ]; then
-            cp "$(pwd -P)/${L_NAME_LOWER}/versions.cfg" .
-        fi
+        local L_CFG_FILES=`find "$(pwd -P)/${L_NAME_LOWER}" -iname "*.cfg"`
+
+        for CFG_FILE in $L_CFG_FILES; do
+            cp "$CFG_FILE" .
+        done
     fi
 }
 


### PR DESCRIPTION
Problem: issue #11 
Fix: By using the _find_ command, the script is able to locate all configuration files for a tool build script.