### PR TITLE
[WIP] Add build dependency removal logic

### DIFF
--- a/build_tools/install_build_essentials.sh
+++ b/build_tools/install_build_essentials.sh
@@ -18,6 +18,25 @@ set -e
 TOOLS="build-essential git clang gcc meson ninja-build g++ python3-dev \
        make flex bison libc6 binutils gzip bzip2 tar perl autoconf m4 \
        automake gettext gperf dejagnu expect tcl"
+REMOVE_HINT_FILE="remove_after_build.txt"
+       
+# check which tools are not installed, so that they can be removed
+# after installation
+NOT_INSTALLED=""
+APTLIST=`apt list --installed`
+
+for TOOL in $TOOLS; do
+    case "$APTLIST" in
+        *"${TOOL}/"*)
+            echo "found $TOOL"
+            continue
+            ;;
+    esac
+    
+    NOT_INSTALLED="${NOT_INSTALLED} $TOOL"
+done
+
+echo -e "$NOT_INSTALLED" >> $REMOVE_HINT_FILE
 
 # install and upgrade tools
 apt-get update

--- a/build_tools/uninstall_build_essentials.sh
+++ b/build_tools/uninstall_build_essentials.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Author: Harald Heckmann <mail@haraldheckmann.de>
+# Date: Dec. 29 2020
+# Project: QuantumRisc (RheinMain University) <Steffen.Reith@hs-rm.de>
+
+RED='\033[1;31m'
+NC='\033[0m'
+
+# require sudo
+if [[ $UID != 0 ]]; then
+    echo "Please run this script with sudo:"
+    echo "sudo $0 $*"
+    exit 1
+fi
+
+# exit when any command fails
+set -e
+
+# file that contains the newly added build tools
+REMOVE_HINT_FILE="remove_after_build.txt"
+
+if [ ! -f $REMOVE_HINT_FILE ]; then
+    echo -e "${RED}Error: File \"${REMOVE_HINT_FILE}\" not found.${NC}"
+    exit 1
+fi
+       
+# remove newly added build tools
+while IFS= read -r LINE; do
+    for APTPKG in $LINE; do
+        apt-get remove -y $APTPKG
+    done
+done < $REMOVE_HINT_FILE
+
+apt-get autoremove -y
+rm $REMOVE_HINT_FILE


### PR DESCRIPTION
Issue: #59 
Fix:

- [x] Store common build dependencies, that were previously not installed on the system, in a file
- [x] Implement build dependency uninstall script
- [ ] Store build dependencies for every single tool, that were previously not installed on the system, in a file
- [ ] Implement build dependency uninstall script for every single tool
- [ ] Integrate build dependency cleanup to install_everything.sh