### PR TITLE
Add riscv build option for vector extensions

### DIFF
--- a/build_tools/config.cfg
+++ b/build_tools/config.cfg
@@ -198,6 +198,8 @@ RISCV_NEWLIB_DIR=default
 # Note: You can specify the version of every single tool of this toolchain in
 # ./riscv_tools/versions.cfg
 RISCV_NEWLIB_TAG=default
+# Build with experimental vector extensions?
+RISCV_NEWLIB_VECTOR=false
 # Extend PATH by RiscV-GNU-Toolchain path? 
 RISCV_NEWLIB_EXTEND_PATH=true
 # Specify user to install the toolchain for (default = everybody)
@@ -218,6 +220,8 @@ RISCV_LINUX_DIR=default
 # Note: You can specify the version of every single tool of this toolchain in
 # ./riscv_tools/versions.cfg
 RISCV_LINUX_TAG=default
+# Build with experimental vector extensions?
+RISCV_LINUX_VECTOR=false
 # Extend PATH by RiscV-GNU-Toolchain path? 
 RISCV_LINUX_EXTEND_PATH=true
 # Specify user to install the toolchain for (default = everybody)

--- a/build_tools/install_build_essentials.sh
+++ b/build_tools/install_build_essentials.sh
@@ -17,7 +17,12 @@ set -e
 # required tools
 TOOLS="build-essential git clang gcc meson ninja-build g++ python3-dev \
        make flex bison libc6 binutils gzip bzip2 tar perl autoconf m4 \
-       automake gettext gperf dejagnu expect tcl xdg-user-dirs"
+<<<<<<< HEAD
+       automake gettext gperf dejagnu expect tcl xdg-user-dirs \
+       python-is-python3"
+=======
+       automake gettext gperf dejagnu expect tcl python-is-python3"
+>>>>>>> added -v flag to build riscv with vector extensions
 
 # install and upgrade tools
 apt-get update

--- a/build_tools/libraries/library.sh
+++ b/build_tools/libraries/library.sh
@@ -131,6 +131,12 @@ function parameters_tool_riscv {
         eval "$2=\"${!2} -e\""
     fi
     
+    # set "v" parameter
+    if [ "$(eval "echo $`echo $1`_VECTOR)" = true ]; then
+        eval "$2=\"${!2} -v\""
+    fi
+    
+    
     # set "u" parameter
     local L_BUILD_USER="$(eval "echo $`echo $1`_USER")"
     


### PR DESCRIPTION
Issue: #63 
Solution: Added -v flag to install_riscv.sh. Using this flag forces to pull the rvv-extrinsic branch of the riscv-gnu-toolchain project, which upon building implicitly includes vectort extensions. Also mirrored the new flag in the config file for install_everything.sh